### PR TITLE
added LONGFILE_POSIX in wave-ulit packer

### DIFF
--- a/wave-utils/src/main/java/io/seqera/wave/util/Packer.java
+++ b/wave-utils/src/main/java/io/seqera/wave/util/Packer.java
@@ -74,6 +74,7 @@ public class Packer {
 
     <T extends OutputStream> T makeTar(Map<String,Path> entries, T target) throws IOException  {
         try ( final TarArchiveOutputStream archive = new TarArchiveOutputStream(target) ) {
+            archive.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
             final TreeSet<String> sorted = new TreeSet<>(entries.keySet());
             for (String name : sorted ) {
                 final Path targetPath = entries.get(name);


### PR DESCRIPTION
This fixed the following error in wave-cli
 java.lang.IllegalArgumentException: file name '.git/logs/refs/remotes/origin/26-an-exception-is-reported-when-a-context-file-path-is-longer-than-100-chars' is too long ( > 100 bytes)