### PR TITLE
Update Spack templates/tests: add OS packages

### DIFF
--- a/wave-utils/src/main/resources/templates/spack/dockerfile-spack-file.txt
+++ b/wave-utils/src/main/resources/templates/spack/dockerfile-spack-file.txt
@@ -5,6 +5,11 @@ COPY --from=builder /opt/spack-env /opt/spack-env
 COPY --from=builder /opt/software /opt/software
 COPY --from=builder /opt/._view /opt/._view
 
+# General utility OS packages
+RUN apt update -y && \
+    apt install -y procps libgomp1 && \
+    rm -rf /var/lib/apt/lists/*
+
 # Entrypoint for Singularity
 RUN mkdir -p /.singularity.d/env && \
     cp -p /opt/spack-env/z10_spack_environment.sh /.singularity.d/env/91-environment.sh

--- a/wave-utils/src/main/resources/templates/spack/singularityfile-spack-file.txt
+++ b/wave-utils/src/main/resources/templates/spack/singularityfile-spack-file.txt
@@ -9,4 +9,7 @@ stage: final
     /opt/spack-env/z10_spack_environment.sh /.singularity.d/env/91-environment.sh
 
 %post
+    apt update -y
+    apt install -y procps libgomp1
+    rm -rf /var/lib/apt/lists/*
     {{add_commands}}

--- a/wave-utils/src/test/groovy/io/seqera/wave/util/DockerHelperTest.groovy
+++ b/wave-utils/src/test/groovy/io/seqera/wave/util/DockerHelperTest.groovy
@@ -347,6 +347,11 @@ class DockerHelperTest extends Specification {
                 COPY --from=builder /opt/software /opt/software
                 COPY --from=builder /opt/._view /opt/._view
                 
+                # General utility OS packages
+                RUN apt update -y && \
+                    apt install -y procps libgomp1 && \
+                    rm -rf /var/lib/apt/lists/*
+                
                 # Entrypoint for Singularity
                 RUN mkdir -p /.singularity.d/env && \\
                     cp -p /opt/spack-env/z10_spack_environment.sh /.singularity.d/env/91-environment.sh
@@ -380,6 +385,11 @@ class DockerHelperTest extends Specification {
                 COPY --from=builder /opt/software /opt/software
                 COPY --from=builder /opt/._view /opt/._view
                 
+                # General utility OS packages
+                RUN apt update -y && \
+                    apt install -y procps libgomp1 && \
+                    rm -rf /var/lib/apt/lists/*
+                
                 # Entrypoint for Singularity
                 RUN mkdir -p /.singularity.d/env && \\
                     cp -p /opt/spack-env/z10_spack_environment.sh /.singularity.d/env/91-environment.sh
@@ -404,6 +414,11 @@ class DockerHelperTest extends Specification {
                 COPY --from=builder /opt/spack-env /opt/spack-env
                 COPY --from=builder /opt/software /opt/software
                 COPY --from=builder /opt/._view /opt/._view
+                
+                # General utility OS packages
+                RUN apt update -y && \
+                    apt install -y procps libgomp1 && \
+                    rm -rf /var/lib/apt/lists/*
                 
                 # Entrypoint for Singularity
                 RUN mkdir -p /.singularity.d/env && \\
@@ -717,6 +732,9 @@ class DockerHelperTest extends Specification {
                 /opt/spack-env/z10_spack_environment.sh /.singularity.d/env/91-environment.sh
             
             %post
+                apt update -y
+                apt install -y procps libgomp1
+                rm -rf /var/lib/apt/lists/*
                 USER hola
             '''.stripIndent()
     }

--- a/wave-utils/src/test/groovy/io/seqera/wave/util/DockerHelperTest.groovy
+++ b/wave-utils/src/test/groovy/io/seqera/wave/util/DockerHelperTest.groovy
@@ -348,10 +348,10 @@ class DockerHelperTest extends Specification {
                 COPY --from=builder /opt/._view /opt/._view
                 
                 # General utility OS packages
-                RUN apt update -y && \
-                    apt install -y procps libgomp1 && \
+                RUN apt update -y && \\
+                    apt install -y procps libgomp1 && \\
                     rm -rf /var/lib/apt/lists/*
-                
+
                 # Entrypoint for Singularity
                 RUN mkdir -p /.singularity.d/env && \\
                     cp -p /opt/spack-env/z10_spack_environment.sh /.singularity.d/env/91-environment.sh
@@ -386,8 +386,8 @@ class DockerHelperTest extends Specification {
                 COPY --from=builder /opt/._view /opt/._view
                 
                 # General utility OS packages
-                RUN apt update -y && \
-                    apt install -y procps libgomp1 && \
+                RUN apt update -y && \\
+                    apt install -y procps libgomp1 && \\
                     rm -rf /var/lib/apt/lists/*
                 
                 # Entrypoint for Singularity
@@ -416,8 +416,8 @@ class DockerHelperTest extends Specification {
                 COPY --from=builder /opt/._view /opt/._view
                 
                 # General utility OS packages
-                RUN apt update -y && \
-                    apt install -y procps libgomp1 && \
+                RUN apt update -y && \\
+                    apt install -y procps libgomp1 && \\
                     rm -rf /var/lib/apt/lists/*
                 
                 # Entrypoint for Singularity


### PR DESCRIPTION
This  PR updates the Docker/Singularity templates for the runner images for Spack Wave, to add general utility OS packages `libgomp` and `procps` (assuming Ubuntu/Debian, i.e. using `apt` to install).

From prototype tests with Spack containers, `libgomp` is crucial in the runner images, to allow any multi-threaded application to run properly rather than crash. Therefore it should really be in the runner image.

I have added `procps` as I remember it can be useful for metric collection when using Tower; up to you whether still relevant or not.
