### PR TITLE
Add no arg constructor to FusionVersion for jackson deserialization

### DIFF
--- a/wave-api/src/main/java/io/seqera/wave/api/FusionVersion.java
+++ b/wave-api/src/main/java/io/seqera/wave/api/FusionVersion.java
@@ -33,9 +33,9 @@ public class FusionVersion {
     static final private Pattern VERSION_JSON = Pattern.compile(".*/v(\\d+(?:\\.\\w+)*)-(\\w*)\\.json$");
     static final private Pattern VERSION_TARGZ = Pattern.compile(".*/pkg\\/(\\d+(?:\\/\\w+)+)\\/fusion-(\\w+)\\.tar\\.gz$");
 
-    final public String number;
+    public String number;
 
-    final public String arch;
+    public String arch;
 
     FusionVersion(String number, String arch) {
         this.number = number;
@@ -68,5 +68,9 @@ public class FusionVersion {
                     matcher_targz.group(2));
         }
         return null;
+    }
+
+    /* required by jackson deserialization - do not remove */
+    public FusionVersion() {
     }
 }


### PR DESCRIPTION
After adding FusionVersion in wave persistence, there is bug in GET /container-token/{token} API
This PR will fix this bug
```
13:13:49.258 [io-executor-thread-3] ERROR io.seqera.wave.ErrorHandler - Cannot construct instance of `io.seqera.wave.api.FusionVersion` (no Creators, like default constructor, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
 at [Source: (String)"[{"result":[{"buildId":"71a27aaebcecfcc2","buildNew":true,"containerConfig":{"entrypoint":["/usr/bin/fusion"],"layers":[{"gzipDigest":"sha256:02034f9e863d873bb5e00e3483678852ad72ebba52da857b44d881bfde5cdde5","gzipSize":28266678,"location":"https://fusionfs.seqera.io/releases/pkg/2/2/12/fusion-arm64.tar.gz","tarDigest":"sha256:44d5031530161218608c5ad949c74d4e33bfeac7d113a58e1340843ed6239e6b"}]},"containerFile":"FROM alpine\n\nRUN apk update && apk add bash cowsay \\\n        --update-cache \\\n  "[truncated 789 chars]; line: 1, column: 859] (through reference chain: java.util.ArrayList[0]->io.seqera.wave.service.persistence.impl.SurrealResult["result"]->java.lang.Object[][0]->io.seqera.wave.service.persistence.WaveContainerRecord["fusionVersion"]) - Error ID: 5321184521ee - Request: GET /container-token/2a44b837d9b4
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `io.seqera.wave.api.FusionVersion` (no Creators, like default constructor, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
 at [Source: (String)"[{"result":[{"buildId":"71a27aaebcecfcc2","buildNew":true,"containerConfig":{"entrypoint":["/usr/bin/fusion"],"layers":[{"gzipDigest":"sha256:02034f9e863d873bb5e00e3483678852ad72ebba52da857b44d881bfde5cdde5","gzipSize":28266678,"location":"https://fusionfs.seqera.io/releases/pkg/2/2/12/fusion-arm64.tar.gz","tarDigest":"sha256:44d5031530161218608c5ad949c74d4e33bfeac7d113a58e1340843ed6239e6b"}]},"containerFile":"FROM alpine\n\nRUN apk update && apk add bash cowsay \\\n        --update-cache \\\n  "[truncated 789 chars]; line: 1, column: 859] (through reference chain: java.util.ArrayList[0]->io.seqera.wave.service.persistence.impl.SurrealResult["result"]->java.lang.Object[][0]->io.seqera.wave.service.persistence.WaveContainerRecord["fusionVersion"])
	at com.fasterxml.jackson.databind.exc.InvalidDefinitionException.from(InvalidDefinitionException.java:67)
	at com.fasterxml.jackson.databind.DeserializationContext.reportBadDefinition(DeserializationContext.java:1915)
	at com.fasterxml.jackson.databind.DatabindContext.reportBadDefinition(DatabindContext.java:414)
	at com.fasterxml.jackson.databind.DeserializationContext.handleMissingInstantiator(DeserializationContext.java:1360)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1424)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:352)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:185)
	at com.fasterxml.jackson.databind.deser.impl.FieldProperty.deserializeAndSet(FieldProperty.java:138)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:314)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:177)
	at com.fasterxml.jackson.databind.deser.std.ObjectArrayDeserializer.deserialize(ObjectArrayDeserializer.java:216)
	at com.fasterxml.jackson.databind.deser.std.ObjectArrayDeserializer.deserialize(ObjectArrayDeserializer.java:26)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:314)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:177)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer._deserializeFromArray(CollectionDeserializer.java:359)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:244)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:28)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:323)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4825)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3772)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3755)
	at io.seqera.wave.util.JacksonHelper.fromJson(JacksonHelper.groovy:84)
	at io.seqera.wave.service.persistence.impl.SurrealPersistenceService.loadContainerRequest(SurrealPersistenceService.groovy:175)
	at io.seqera.wave.controller.ContainerTokenController.describeContainerRequest(ContainerTokenController.groovy:324)
	at io.seqera.wave.controller.$ContainerTokenController$Definition$Exec.dispatch(Unknown Source)
	at io.micronaut.context.AbstractExecutableMethodsDefinition$DispatchedExecutableMethod.invoke(AbstractExecutableMethodsDefinition.java:371)
	at io.micronaut.context.DefaultBeanContext$4.invoke(DefaultBeanContext.java:594)
	at io.micronaut.web.router.AbstractRouteMatch.execute(AbstractRouteMatch.java:303)
	at io.micronaut.web.router.RouteMatch.execute(RouteMatch.java:111)
	at io.micronaut.http.context.ServerRequestContext.with(ServerRequestContext.java:103)
	at io.micronaut.http.server.RouteExecutor.lambda$executeRoute$14(RouteExecutor.java:659)
	at reactor.core.publisher.FluxDeferContextual.subscribe(FluxDeferContextual.java:49)
	at reactor.core.publisher.InternalFluxOperator.subscribe(InternalFluxOperator.java:62)
	at reactor.core.publisher.FluxSubscribeOn$SubscribeOnSubscriber.run(FluxSubscribeOn.java:194)
	at io.micronaut.reactive.reactor.instrument.ReactorInstrumentation.lambda$init$0(ReactorInstrumentation.java:62)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:84)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:37)
	at io.micrometer.core.instrument.composite.CompositeTimer.recordCallable(CompositeTimer.java:129)
	at io.micrometer.core.instrument.Timer.lambda$wrap$1(Timer.java:206)
	at io.micronaut.scheduling.instrument.InvocationInstrumenterWrappedCallable.call(InvocationInstrumenterWrappedCallable.java:53)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1589)
```