### PR TITLE
bump github actions to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,13 +31,13 @@ jobs:
         run: env | sort
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           submodules: true
 
       - name: Setup Java ${{ matrix.java_version }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{matrix.java_version}}
           distribution: 'adopt'


### PR DESCRIPTION
This PR will remove the warning in GitHub actions by updating them to latest version
<img width="1470" alt="Screenshot 2024-03-07 at 17 20 05" src="https://github.com/seqeralabs/libseqera/assets/6575288/446aa6d4-d5ad-41b7-9534-77110366203d">
