### PR TITLE
Bump Groovy 4 + Micronaut 4.4 as deps

### DIFF
--- a/buildSrc/src/main/groovy/io.seqera.java-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.seqera.java-library-conventions.gradle
@@ -16,7 +16,7 @@ repositories {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 
@@ -44,13 +44,13 @@ dependencies {
 
     testImplementation 'ch.qos.logback:logback-core:1.2.11'
     testImplementation 'ch.qos.logback:logback-classic:1.2.11'
-    testImplementation "org.codehaus.groovy:groovy:3.0.15"
-    testImplementation "org.codehaus.groovy:groovy-nio:3.0.15"
-    testImplementation ("org.codehaus.groovy:groovy-test:3.0.17")
+    testImplementation "org.apache.groovy:groovy:4.0.21"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.21"
+    testImplementation ("org.apache.groovy:groovy-test:4.0.21")
     testImplementation ("cglib:cglib-nodep:3.3.0")
     testImplementation ("org.objenesis:objenesis:3.2")
-    testImplementation ("org.spockframework:spock-core:2.3-groovy-3.0") { exclude group: 'org.codehaus.groovy'; exclude group: 'net.bytebuddy' }
-    testImplementation ('org.spockframework:spock-junit4:2.3-groovy-3.0') { exclude group: 'org.codehaus.groovy'; exclude group: 'net.bytebuddy' }
+    testImplementation ("org.spockframework:spock-core:2.3-groovy-4.0") { exclude group: 'org.apache.groovy'; exclude group: 'net.bytebuddy' }
+    testImplementation ('org.spockframework:spock-junit4:2.3-groovy-4.0') { exclude group: 'org.apache.groovy'; exclude group: 'net.bytebuddy' }
 }
 
 tasks.withType(Test) {

--- a/lib-mail/build.gradle
+++ b/lib-mail/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'io.seqera.groovy-library-conventions'
     // Micronaut minimal lib
     // https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/
-    id "io.micronaut.minimal.library" version '3.7.10'
+    id "io.micronaut.minimal.library" version '4.1.2'
 }
 
 repositories {
@@ -17,12 +17,12 @@ dependencies {
     compileOnly "io.micronaut:micronaut-inject-groovy"
     implementation "io.seqera:wave-utils:0.5.0"
     implementation "ch.qos.logback:logback-classic:1.2.11"
-    implementation "org.codehaus.groovy:groovy:3.0.15"
-    implementation "org.codehaus.groovy:groovy-nio:3.0.15"
-    implementation "org.codehaus.groovy:groovy-templates:3.0.15"
+    implementation "org.apache.groovy:groovy:4.0.21"
+    implementation "org.apache.groovy:groovy-nio:4.0.21"
+    implementation "org.apache.groovy:groovy-templates:4.0.21"
     api "com.sun.mail:javax.mail:1.6.2"
     api "org.jsoup:jsoup:1.15.3"
-    implementation("io.micronaut:micronaut-runtime:3.3.4")
+    implementation("io.micronaut:micronaut-runtime")
 
     testImplementation "org.subethamail:subethasmtp:3.1.7"
 }
@@ -31,10 +31,20 @@ group = 'io.seqera'
 version = "${project.file('VERSION').text.trim()}"
 
 micronaut {
-    version '3.9.4'
+    version '4.4.3'
     runtime("netty")
     testRuntime("spock2")
     processing {
         incremental(true)
     }
+}
+
+// Micronaut 4 requires Java 17 as target compatibility
+compileJava {
+    options.release.set(17)
+}
+
+tasks.withType(GroovyCompile) {
+    sourceCompatibility = '17'
+    targetCompatibility = '17'
 }


### PR DESCRIPTION
This PR bumps Groovy 4 and Micronaut as project deps.

Also, upgrades the Java bytecode target to Java 17 for `lib-mail` project as required by Micronaut 4 dependency.