### PR TITLE
Add conda lockfile export

### DIFF
--- a/wave-utils/src/main/resources/templates/conda/dockerfile-conda-file.txt
+++ b/wave-utils/src/main/resources/templates/conda/dockerfile-conda-file.txt
@@ -2,6 +2,7 @@ FROM {{base_image}}
 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
 RUN micromamba install -y -n base -f /tmp/conda.yml \
     {{base_packages}}
+    && micromamba env export --explicit > environment.lock.yml \
     && micromamba clean -a -y
 USER root
 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"

--- a/wave-utils/src/main/resources/templates/conda/dockerfile-conda-file.txt
+++ b/wave-utils/src/main/resources/templates/conda/dockerfile-conda-file.txt
@@ -2,7 +2,7 @@ FROM {{base_image}}
 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
 RUN micromamba install -y -n base -f /tmp/conda.yml \
     {{base_packages}}
-    && micromamba env export --explicit > environment.lock.yml \
+    && micromamba env export --explicit > environment.lock \
     && micromamba clean -a -y
 USER root
 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"

--- a/wave-utils/src/main/resources/templates/conda/dockerfile-conda-packages.txt
+++ b/wave-utils/src/main/resources/templates/conda/dockerfile-conda-packages.txt
@@ -2,7 +2,7 @@ FROM {{base_image}}
 RUN \
     micromamba install -y -n base {{channel_opts}} {{target}} \
     {{base_packages}}
-    && micromamba env export --explicit > environment.lock.yml \
+    && micromamba env export --explicit > environment.lock \
     && micromamba clean -a -y
 USER root
 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"

--- a/wave-utils/src/main/resources/templates/conda/dockerfile-conda-packages.txt
+++ b/wave-utils/src/main/resources/templates/conda/dockerfile-conda-packages.txt
@@ -2,6 +2,7 @@ FROM {{base_image}}
 RUN \
     micromamba install -y -n base {{channel_opts}} {{target}} \
     {{base_packages}}
+    && micromamba env export --explicit > environment.lock.yml \
     && micromamba clean -a -y
 USER root
 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"

--- a/wave-utils/src/test/groovy/io/seqera/wave/util/DockerHelperTest.groovy
+++ b/wave-utils/src/test/groovy/io/seqera/wave/util/DockerHelperTest.groovy
@@ -374,7 +374,7 @@ class DockerHelperTest extends Specification {
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
                 RUN micromamba install -y -n base -f /tmp/conda.yml \\
                     && micromamba install -y -n base foo::bar \\
-                    && micromamba env export --explicit > environment.lock.yml \\
+                    && micromamba env export --explicit > environment.lock \\
                     && micromamba clean -a -y
                 USER root
                 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
@@ -389,7 +389,7 @@ class DockerHelperTest extends Specification {
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
                 RUN micromamba install -y -n base -f /tmp/conda.yml \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
-                    && micromamba env export --explicit > environment.lock.yml \\
+                    && micromamba env export --explicit > environment.lock \\
                     && micromamba clean -a -y
                 USER root
                 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
@@ -407,7 +407,7 @@ class DockerHelperTest extends Specification {
                 RUN \\
                     micromamba install -y -n base -c conda-forge -c defaults bwa=0.7.15 salmon=1.1.1 \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
-                    && micromamba env export --explicit > environment.lock.yml \\
+                    && micromamba env export --explicit > environment.lock \\
                     && micromamba clean -a -y
                 USER root
                 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
@@ -426,7 +426,7 @@ class DockerHelperTest extends Specification {
                 RUN \\
                     micromamba install -y -n base -c conda-forge -c defaults bwa=0.7.15 salmon=1.1.1 \\
                     && micromamba install -y -n base foo::one bar::two \\
-                    && micromamba env export --explicit > environment.lock.yml \\
+                    && micromamba env export --explicit > environment.lock \\
                     && micromamba clean -a -y
                 USER root
                 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
@@ -444,7 +444,7 @@ class DockerHelperTest extends Specification {
                 RUN \\
                     micromamba install -y -n base -c foo -c bar bwa=0.7.15 salmon=1.1.1 \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
-                    && micromamba env export --explicit > environment.lock.yml \\
+                    && micromamba env export --explicit > environment.lock \\
                     && micromamba clean -a -y
                 USER root
                 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
@@ -463,7 +463,7 @@ class DockerHelperTest extends Specification {
                 RUN \\
                     micromamba install -y -n base -c conda-forge -c defaults bwa=0.7.15 salmon=1.1.1 \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
-                    && micromamba env export --explicit > environment.lock.yml \\
+                    && micromamba env export --explicit > environment.lock \\
                     && micromamba clean -a -y
                 USER root
                 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
@@ -485,7 +485,7 @@ class DockerHelperTest extends Specification {
                 RUN \\
                     micromamba install -y -n base -c conda-forge -c defaults -f https://foo.com/some/conda-lock.yml \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
-                    && micromamba env export --explicit > environment.lock.yml \\
+                    && micromamba env export --explicit > environment.lock \\
                     && micromamba clean -a -y
                 USER root
                 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"


### PR DESCRIPTION
Generate an explicit lockfile for the created environment.

Exposing this will allow people to exactly replicate the conda build on their own systems.

> [!WARNING]
> I haven't tried running anything here, this is just from me testing outside Wave in the docker images. Please confirm that this works as expected in builds.

'cc @munishchouhan 