### PR TITLE
Bump micromamba-1.5.9

### DIFF
--- a/wave-api/src/main/java/io/seqera/wave/config/CondaOpts.java
+++ b/wave-api/src/main/java/io/seqera/wave/config/CondaOpts.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 public class CondaOpts {
-    final public static String DEFAULT_MAMBA_IMAGE = "mambaorg/micromamba:1.5.8-lunar";
+    final public static String DEFAULT_MAMBA_IMAGE = "mambaorg/micromamba:1.5.9-lunar";
     final public static String DEFAULT_PACKAGES = "conda-forge::procps-ng";
 
     public String mambaImage;

--- a/wave-api/src/test/groovy/io/seqera/wave/config/CondaOptsTest.groovy
+++ b/wave-api/src/test/groovy/io/seqera/wave/config/CondaOptsTest.groovy
@@ -75,7 +75,7 @@ class CondaOptsTest extends Specification {
         new CondaOpts(OPTS).toString() == EXPECTED
         where:
         OPTS    | EXPECTED
-        [:]     | "CondaOpts(mambaImage=mambaorg/micromamba:1.5.8-lunar; basePackages=conda-forge::procps-ng, commands=null)"
+        [:]     | "CondaOpts(mambaImage=mambaorg/micromamba:1.5.9-lunar; basePackages=conda-forge::procps-ng, commands=null)"
         [mambaImage: 'foo:1.0', basePackages: 'this that', commands: ['X','Y']] \
                 | "CondaOpts(mambaImage=foo:1.0; basePackages=this that, commands=X,Y)"
     }

--- a/wave-utils/src/test/groovy/io/seqera/wave/util/DockerHelperTest.groovy
+++ b/wave-utils/src/test/groovy/io/seqera/wave/util/DockerHelperTest.groovy
@@ -370,7 +370,7 @@ class DockerHelperTest extends Specification {
 
         expect:
         DockerHelper.condaFileToDockerFile(CONDA_OPTS)== '''\
-                FROM mambaorg/micromamba:1.5.8-lunar
+                FROM mambaorg/micromamba:1.5.9-lunar
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
                 RUN micromamba install -y -n base -f /tmp/conda.yml \\
                     && micromamba install -y -n base foo::bar \\
@@ -384,7 +384,7 @@ class DockerHelperTest extends Specification {
 
         expect:
         DockerHelper.condaFileToDockerFile(new CondaOpts([:]))== '''\
-                FROM mambaorg/micromamba:1.5.8-lunar
+                FROM mambaorg/micromamba:1.5.9-lunar
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
                 RUN micromamba install -y -n base -f /tmp/conda.yml \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
@@ -401,7 +401,7 @@ class DockerHelperTest extends Specification {
         def CHANNELS = ['conda-forge', 'defaults']
         expect:
         DockerHelper.condaPackagesToDockerFile(PACKAGES, CHANNELS, new CondaOpts([:])) == '''\
-                FROM mambaorg/micromamba:1.5.8-lunar
+                FROM mambaorg/micromamba:1.5.9-lunar
                 RUN \\
                     micromamba install -y -n base -c conda-forge -c defaults bwa=0.7.15 salmon=1.1.1 \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
@@ -419,7 +419,7 @@ class DockerHelperTest extends Specification {
 
         expect:
         DockerHelper.condaPackagesToDockerFile(PACKAGES, CHANNELS, CONDA_OPTS) == '''\
-                FROM mambaorg/micromamba:1.5.8-lunar
+                FROM mambaorg/micromamba:1.5.9-lunar
                 RUN \\
                     micromamba install -y -n base -c conda-forge -c defaults bwa=0.7.15 salmon=1.1.1 \\
                     && micromamba install -y -n base foo::one bar::two \\
@@ -436,7 +436,7 @@ class DockerHelperTest extends Specification {
 
         expect:
         DockerHelper.condaPackagesToDockerFile(PACKAGES, CHANNELS, new CondaOpts([:])) == '''\
-                FROM mambaorg/micromamba:1.5.8-lunar
+                FROM mambaorg/micromamba:1.5.9-lunar
                 RUN \\
                     micromamba install -y -n base -c foo -c bar bwa=0.7.15 salmon=1.1.1 \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
@@ -792,7 +792,7 @@ class DockerHelperTest extends Specification {
         expect:
         DockerHelper.condaFileToSingularityFile(CONDA_OPTS)== '''\
                 BootStrap: docker
-                From: mambaorg/micromamba:1.5.8-lunar
+                From: mambaorg/micromamba:1.5.9-lunar
                 %files
                     {{wave_context_dir}}/conda.yml /scratch/conda.yml
                 %post
@@ -809,7 +809,7 @@ class DockerHelperTest extends Specification {
         expect:
         DockerHelper.condaFileToSingularityFile(new CondaOpts([:]))== '''\
                 BootStrap: docker
-                From: mambaorg/micromamba:1.5.8-lunar
+                From: mambaorg/micromamba:1.5.9-lunar
                 %files
                     {{wave_context_dir}}/conda.yml /scratch/conda.yml
                 %post
@@ -829,7 +829,7 @@ class DockerHelperTest extends Specification {
         expect:
         DockerHelper.condaPackagesToSingularityFile(PACKAGES, CHANNELS, new CondaOpts([:])) == '''\
                 BootStrap: docker
-                From: mambaorg/micromamba:1.5.8-lunar
+                From: mambaorg/micromamba:1.5.9-lunar
                 %post
                     micromamba install -y -n base -c conda-forge -c defaults bwa=0.7.15 salmon=1.1.1
                     micromamba install -y -n base conda-forge::procps-ng
@@ -848,7 +848,7 @@ class DockerHelperTest extends Specification {
         expect:
         DockerHelper.condaPackagesToSingularityFile(PACKAGES, CHANNELS, CONDA_OPTS) == '''\
                 BootStrap: docker
-                From: mambaorg/micromamba:1.5.8-lunar
+                From: mambaorg/micromamba:1.5.9-lunar
                 %post
                     micromamba install -y -n base -c conda-forge -c defaults bwa=0.7.15 salmon=1.1.1
                     micromamba install -y -n base foo::one bar::two
@@ -866,7 +866,7 @@ class DockerHelperTest extends Specification {
         expect:
         DockerHelper.condaPackagesToSingularityFile(PACKAGES, CHANNELS, new CondaOpts([:])) == '''\
                 BootStrap: docker
-                From: mambaorg/micromamba:1.5.8-lunar
+                From: mambaorg/micromamba:1.5.9-lunar
                 %post
                     micromamba install -y -n base -c foo -c bar bwa=0.7.15 salmon=1.1.1
                     micromamba install -y -n base conda-forge::procps-ng


### PR DESCRIPTION
This PR bumps [micromamba-docker 1.5.9](https://github.com/mamba-org/micromamba-docker/releases/tag/v1.5.9) 