### PR TITLE
Extract condition into class

### DIFF
--- a/lib-data-stream-redis/src/main/groovy/io/seqera/data/stream/RedisAvailabilityCondition.groovy
+++ b/lib-data-stream-redis/src/main/groovy/io/seqera/data/stream/RedisAvailabilityCondition.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.data.stream
+
+import groovy.transform.CompileStatic
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.condition.Condition
+import io.micronaut.context.condition.ConditionContext
+import io.micronaut.context.env.Environment
+
+/**
+ * Custom condition to determine Redis availability for message stream implementations.
+ *
+ * <p>This condition evaluates whether Redis should be used for message streaming based on:</p>
+ * <ul>
+ *   <li>Presence of {@code redis.uri} property</li>
+ *   <li>Active environment profiles containing 'redis'</li>
+ * </ul>
+ *
+ * <p>Usage with {@code @Requires(condition = RedisAvailabilityCondition.class)}</p>
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@CompileStatic
+class RedisAvailabilityCondition implements Condition {
+
+    @Override
+    boolean matches(ConditionContext context) {
+        final applicationContext = (context.getBeanContext() as ApplicationContext)
+        final applicationEnvironment = applicationContext.getEnvironment()
+        return hasRedisUri(applicationEnvironment) || isRedisEnvironmentActive(applicationEnvironment)
+    }
+
+    /**
+     * Check if the redis.uri property is configured
+     */
+    static boolean hasRedisUri(Environment env) {
+        return env.getPropertyEntry("redis.uri").isPresent()
+    }
+
+    /**
+     * Check if 'redis' environment is active
+     */
+    static boolean isRedisEnvironmentActive(Environment env) {
+        return 'redis' in env.getActiveNames()
+    }
+}

--- a/lib-data-stream-redis/src/main/groovy/io/seqera/data/stream/impl/LocalMessageStream.groovy
+++ b/lib-data-stream-redis/src/main/groovy/io/seqera/data/stream/impl/LocalMessageStream.groovy
@@ -59,7 +59,7 @@ import jakarta.inject.Singleton
  * @since 1.0
  */
 @Slf4j
-@Requires(notEnv = 'redis')
+@Requires(missingBeans = RedisMessageStream.class)
 @Singleton
 @CompileStatic
 class LocalMessageStream implements MessageStream<String> {

--- a/lib-data-stream-redis/src/main/groovy/io/seqera/data/stream/impl/RedisMessageStream.groovy
+++ b/lib-data-stream-redis/src/main/groovy/io/seqera/data/stream/impl/RedisMessageStream.groovy
@@ -24,6 +24,7 @@ import groovy.util.logging.Slf4j
 import io.micronaut.context.annotation.Requires
 import io.seqera.data.stream.MessageConsumer
 import io.seqera.data.stream.MessageStream
+import io.seqera.data.stream.RedisAvailabilityCondition
 import io.seqera.random.LongRndKey
 import jakarta.annotation.PostConstruct
 import jakarta.inject.Inject
@@ -72,7 +73,7 @@ import redis.clients.jedis.resps.StreamEntry
  * @since 1.0
  */
 @Slf4j
-@Requires(env = 'redis')
+@Requires(condition = RedisAvailabilityCondition.class)
 @Singleton
 @CompileStatic
 class RedisMessageStream implements MessageStream<String> {

--- a/lib-data-stream-redis/src/test/groovy/io/seqera/data/stream/RedisAvailabilityConditionTest.groovy
+++ b/lib-data-stream-redis/src/test/groovy/io/seqera/data/stream/RedisAvailabilityConditionTest.groovy
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.data.stream
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.condition.ConditionContext
+import io.micronaut.context.env.Environment
+import spock.lang.Specification
+
+/**
+ * Test RedisAvailabilityCondition functionality
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class RedisAvailabilityConditionTest extends Specification {
+
+    def 'should return true when redis.uri property is set'() {
+        given:
+        def condition = new RedisAvailabilityCondition()
+        def context = createMockContext(true, false)
+
+        when:
+        def result = condition.matches(context)
+
+        then:
+        result
+    }
+
+    def 'should return true when redis environment is active'() {
+        given:
+        def condition = new RedisAvailabilityCondition()
+        def context = createMockContext(false, true)
+
+        when:
+        def result = condition.matches(context)
+
+        then:
+        result
+    }
+
+    def 'should return true when both redis.uri and redis environment are present'() {
+        given:
+        def condition = new RedisAvailabilityCondition()
+        def context = createMockContext(true, true)
+
+        when:
+        def result = condition.matches(context)
+
+        then:
+        result
+    }
+
+    def 'should return false when neither redis.uri nor redis environment are present'() {
+        given:
+        def condition = new RedisAvailabilityCondition()
+        def context = createMockContext(false, false)
+
+        when:
+        def result = condition.matches(context)
+
+        then:
+        !result
+    }
+
+    def 'should test hasRedisUri static method directly'() {
+        expect:
+        RedisAvailabilityCondition.hasRedisUri(createMockEnvironment(true, false))
+        !RedisAvailabilityCondition.hasRedisUri(createMockEnvironment(false, false))
+    }
+
+    def 'should test isRedisEnvironmentActive static method directly'() {
+        expect:
+        RedisAvailabilityCondition.isRedisEnvironmentActive(createMockEnvironment(false, true))
+        !RedisAvailabilityCondition.isRedisEnvironmentActive(createMockEnvironment(false, false))
+    }
+
+    private ConditionContext createMockContext(boolean hasRedisUri, boolean hasRedisEnv) {
+        def env = createMockEnvironment(hasRedisUri, hasRedisEnv)
+        def appContext = Mock(ApplicationContext)
+        def context = Mock(ConditionContext)
+        
+        appContext.getEnvironment() >> env
+        context.getBeanContext() >> appContext
+        
+        return context
+    }
+    
+    private Environment createMockEnvironment(boolean hasRedisUri, boolean hasRedisEnv) {
+        def env = Mock(Environment)
+        env.getPropertyEntry("redis.uri") >> (hasRedisUri ? Optional.of("redis://localhost:6379") : Optional.empty())
+        env.getActiveNames() >> (hasRedisEnv ? ['redis'] : ['test'])
+        return env
+    }
+}


### PR DESCRIPTION
The current way in which the RedisMessageStream fits on Wave configuration but no on platform's one. The aim of this PR is to provide a compatible way so the library can be used in both contexts.

A concrete implementation and not an interface is given since, as far as I know, there is no way to automatically inject the condition upon implementation in the repository using the class. 
At this point, it is important to take into account that the class that is reimplemented is AbstractMessageStream and not RedisMessageStream that will remain as it is. 