### PR TITLE
Add CRAN package support to Wave API and utilities

### DIFF
--- a/wave-api/src/main/java/io/seqera/wave/api/PackagesSpec.java
+++ b/wave-api/src/main/java/io/seqera/wave/api/PackagesSpec.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Objects;
 
 import io.seqera.wave.config.CondaOpts;
+import io.seqera.wave.config.CranOpts;
 
 /**
  * Model a Package environment requirements
@@ -29,7 +30,7 @@ import io.seqera.wave.config.CondaOpts;
  */
 public class PackagesSpec {
 
-    public enum Type { CONDA }
+    public enum Type { CONDA, CRAN }
 
     public Type type;
 
@@ -49,6 +50,11 @@ public class PackagesSpec {
     public CondaOpts condaOpts;
 
     /**
+     * CRAN build options
+     */
+    public CranOpts cranOpts;
+
+    /**
      * channels used for downloading packages
      */
     public List<String> channels;
@@ -62,12 +68,13 @@ public class PackagesSpec {
                 && Objects.equals(environment, that.environment)
                 && Objects.equals(entries, that.entries)
                 && Objects.equals(condaOpts, that.condaOpts)
+                && Objects.equals(cranOpts, that.cranOpts)
                 && Objects.equals(channels, that.channels);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, environment, entries, condaOpts, channels);
+        return Objects.hash(type, environment, entries, condaOpts, cranOpts, channels);
     }
 
     @Override
@@ -77,6 +84,7 @@ public class PackagesSpec {
                 ", envFile='" + environment + '\'' +
                 ", packages=" + entries +
                 ", condaOpts=" + condaOpts +
+                ", cranOpts=" + cranOpts +
                 ", channels=" + ObjectUtils.toString(channels) +
                 '}';
     }
@@ -103,6 +111,11 @@ public class PackagesSpec {
 
     public PackagesSpec withCondaOpts(CondaOpts opts) {
         this.condaOpts = opts;
+        return this;
+    }
+
+    public PackagesSpec withCranOpts(CranOpts opts) {
+        this.cranOpts = opts;
         return this;
     }
 

--- a/wave-api/src/main/java/io/seqera/wave/config/CranOpts.java
+++ b/wave-api/src/main/java/io/seqera/wave/config/CranOpts.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.wave.config;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * CRAN/R build options
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+public class CranOpts {
+    final public static String DEFAULT_R_IMAGE = "rocker/r-ver:4.4.1";
+    final public static String DEFAULT_PACKAGES = "littler r-cran-docopt";
+
+    public String rImage;
+    public List<String> commands;
+    public String basePackages;
+
+    public CranOpts() {
+        this(Map.of());
+    }
+
+    public CranOpts(Map<String,?> opts) {
+        this.rImage = opts.containsKey("rImage") ? opts.get("rImage").toString(): DEFAULT_R_IMAGE;
+        this.commands = opts.containsKey("commands") ? (List<String>)opts.get("commands") : null;
+        this.basePackages = opts.containsKey("basePackages") ? (String)opts.get("basePackages") : DEFAULT_PACKAGES;
+    }
+
+    public CranOpts withRImage(String value) {
+        this.rImage = value;
+        return this;
+    }
+
+    public CranOpts withCommands(List<String> value) {
+        this.commands = value;
+        return this;
+    }
+
+    public CranOpts withBasePackages(String value) {
+        this.basePackages = value;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("CranOpts(rImage=%s; basePackages=%s, commands=%s)",
+                rImage,
+                basePackages,
+                commands != null ? String.join(",", commands) : "null"
+                );
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        CranOpts cranOpts = (CranOpts) object;
+        return Objects.equals(rImage, cranOpts.rImage) && Objects.equals(commands, cranOpts.commands) && Objects.equals(basePackages, cranOpts.basePackages);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rImage, commands, basePackages);
+    }
+}

--- a/wave-utils/src/main/java/io/seqera/wave/util/CranHelper.java
+++ b/wave-utils/src/main/java/io/seqera/wave/util/CranHelper.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.wave.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import io.seqera.wave.config.CranOpts;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Helper class to create Dockerfile for CRAN/R package manager
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+public class CranHelper {
+
+    static public List<String> cranPackagesToList(String packages) {
+        if (packages == null || packages.isEmpty())
+            return null;
+        return Arrays
+                .stream(packages.split(" "))
+                .filter(it -> !StringUtils.isEmpty(it))
+                .map(it -> trim0(it)).collect(Collectors.toList());
+    }
+
+    protected static String trim0(String value) {
+        if( value==null )
+            return null;
+        value = value.trim();
+        while( value.startsWith("'") && value.endsWith("'") )
+            value = value.substring(1,value.length()-1);
+        while( value.startsWith("\"") && value.endsWith("\"") )
+            value = value.substring(1,value.length()-1);
+        return value;
+    }
+
+    static public String cranPackagesToDockerFile(String packages, List<String> repositories, CranOpts opts) {
+        return cranPackagesTemplate0(
+                "/templates/cran/dockerfile-cran-packages.txt",
+                packages,
+                repositories,
+                opts);
+    }
+
+    static public String cranPackagesToSingularityFile(String packages, List<String> repositories, CranOpts opts) {
+        return cranPackagesTemplate0(
+                "/templates/cran/singularityfile-cran-packages.txt",
+                packages,
+                repositories,
+                opts);
+    }
+
+    static protected String cranPackagesTemplate0(String template, String packages, List<String> repositories, CranOpts opts) {
+        final List<String> repos0 = repositories!=null ? repositories : List.of();
+        final boolean singularity = template.contains("/singularityfile");
+        final String repoOpts = buildRepositoryOptions(repos0, singularity);
+        final String image = opts.rImage;
+        final String target = formatPackageTarget(packages);
+        final String basePackages = rInstallBasePackage0(opts.basePackages, singularity);
+        final Map<String,String> binding = new HashMap<>();
+        binding.put("base_image", image);
+        binding.put("repo_opts", repoOpts);
+        binding.put("target", target);
+        String basePackagesPart = "";
+        if (basePackages != null) {
+            if (singularity) {
+                basePackagesPart = "\n    " + basePackages;
+            } else {
+                basePackagesPart = " \\\n    && " + basePackages;
+            }
+        }
+        binding.put("base_packages", basePackagesPart);
+
+        final String result = renderTemplate0(template, binding) ;
+        return addCommands(result, opts.commands, singularity);
+    }
+
+    static public String cranFileToDockerFile(CranOpts opts) {
+        return cranFileTemplate0("/templates/cran/dockerfile-cran-file.txt", opts);
+    }
+
+    static public String cranFileToSingularityFile(CranOpts opts) {
+        return cranFileTemplate0("/templates/cran/singularityfile-cran-file.txt", opts);
+    }
+
+    static protected String cranFileTemplate0(String template, CranOpts opts) {
+        final boolean singularity = template.contains("/singularityfile");
+        final String basePackages = rInstallBasePackage0(opts.basePackages, singularity);
+        final Map<String,String> binding = new HashMap<>();
+        binding.put("base_image", opts.rImage);
+        binding.put("base_packages", basePackages != null ? basePackages : "");
+
+        final String result = renderTemplate0(template, binding, List.of("wave_context_dir"));
+        return addCommands(result, opts.commands, singularity);
+    }
+
+    private static String buildRepositoryOptions(List<String> repositories, boolean singularity) {
+        String repoSetup;
+        if (repositories.isEmpty()) {
+            // Default to CRAN if no repositories specified
+            repoSetup = "R -e \"options(repos = c(CRAN = 'https://cloud.r-project.org/'))\"";
+        } else {
+            final String repoCommands = repositories.stream()
+                    .map(repo -> {
+                        if ("bioconductor".equalsIgnoreCase(repo)) {
+                            return "options(BioC_mirror = 'https://bioconductor.org')";
+                        } else if ("cran".equalsIgnoreCase(repo)) {
+                            return "options(repos = c(CRAN = 'https://cloud.r-project.org/'))";
+                        } else {
+                            return String.format("options(repos = c(CRAN = '%s'))", repo);
+                        }
+                    })
+                    .collect(Collectors.joining("; "));
+            repoSetup = String.format("R -e \"%s\"", repoCommands);
+        }
+        
+        return singularity ? repoSetup : repoSetup + " \\\n   ";
+    }
+
+    private static String formatPackageTarget(String packages) {
+        if (packages.startsWith("http://") || packages.startsWith("https://")) {
+            return packages;
+        }
+        
+        final List<String> packageList = cranPackagesToList(packages);
+        if (packageList == null || packageList.isEmpty()) {
+            return "";
+        }
+        
+        return packageList.stream()
+                .map(pkg -> {
+                    if (pkg.startsWith("bioc::")) {
+                        return String.format("BiocManager::install('%s')", pkg.substring(6));
+                    } else {
+                        return String.format("'%s'", pkg);
+                    }
+                })
+                .collect(Collectors.joining(" "));
+    }
+
+    private static String renderTemplate0(String templatePath, Map<String,String> binding) {
+        return renderTemplate0(templatePath, binding, List.of());
+    }
+
+    private static String renderTemplate0(String templatePath, Map<String,String> binding, List<String> ignore) {
+        final URL template = CranHelper.class.getResource(templatePath);
+        if( template==null )
+            throw new IllegalStateException(String.format("Unable to load template '%s' from classpath", templatePath));
+        try {
+            final InputStream reader = template.openStream();
+            return new TemplateRenderer()
+                    .withIgnore(ignore)
+                    .render(reader, binding);
+        }
+        catch (IOException e) {
+            throw new IllegalStateException(String.format("Unable to read classpath template '%s'", templatePath), e);
+        }
+    }
+
+    private static String rInstallBasePackage0(String basePackages, boolean singularity) {
+        if (StringUtils.isEmpty(basePackages)) {
+            return null;
+        }
+        
+        return String.format("apt-get update && apt-get install -y %s", basePackages);
+    }
+
+    static private String addCommands(String result, List<String> commands, boolean singularity) {
+        if( commands==null || commands.isEmpty() )
+            return result;
+        if( singularity )
+            result += "%post\n";
+        for( String cmd : commands ) {
+            if( singularity ) result += "    ";
+            result += cmd + "\n";
+        }
+        return result;
+    }
+}

--- a/wave-utils/src/main/resources/templates/cran/dockerfile-cran-file.txt
+++ b/wave-utils/src/main/resources/templates/cran/dockerfile-cran-file.txt
@@ -1,0 +1,16 @@
+FROM {{base_image}}
+RUN \
+    {{base_packages}} \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=wave_context_dir . .
+RUN \
+    if [ -f "renv.lock" ]; then \
+        R -e "install.packages('renv'); renv::restore()"; \
+    elif [ -f "install.R" ]; then \
+        Rscript install.R; \
+    else \
+        echo "No renv.lock or install.R file found"; \
+    fi \
+    && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
+USER root
+ENV R_LIBS_USER="/usr/local/lib/R/site-library"

--- a/wave-utils/src/main/resources/templates/cran/dockerfile-cran-packages.txt
+++ b/wave-utils/src/main/resources/templates/cran/dockerfile-cran-packages.txt
@@ -1,0 +1,8 @@
+FROM {{base_image}}
+RUN \
+    {{repo_opts}}{{base_packages}} \
+    && install2.r {{target}} \
+    && rm -rf /tmp/downloaded_packages/ /tmp/*.rds \
+    && rm -rf /var/lib/apt/lists/*
+USER root
+ENV R_LIBS_USER="/usr/local/lib/R/site-library"

--- a/wave-utils/src/main/resources/templates/cran/singularityfile-cran-file.txt
+++ b/wave-utils/src/main/resources/templates/cran/singularityfile-cran-file.txt
@@ -1,0 +1,18 @@
+BootStrap: docker
+From: {{base_image}}
+%files
+    . /opt/wave_context_dir
+%post
+    {{base_packages}}
+    rm -rf /var/lib/apt/lists/*
+    cd /opt/wave_context_dir
+    if [ -f "renv.lock" ]; then
+        R -e "install.packages('renv'); renv::restore()"
+    elif [ -f "install.R" ]; then
+        Rscript install.R
+    else
+        echo "No renv.lock or install.R file found"
+    fi
+    rm -rf /tmp/downloaded_packages/ /tmp/*.rds
+%environment
+    export R_LIBS_USER="/usr/local/lib/R/site-library"

--- a/wave-utils/src/main/resources/templates/cran/singularityfile-cran-packages.txt
+++ b/wave-utils/src/main/resources/templates/cran/singularityfile-cran-packages.txt
@@ -1,0 +1,9 @@
+BootStrap: docker
+From: {{base_image}}
+%post
+    {{repo_opts}}{{base_packages}}
+    install2.r {{target}}
+    rm -rf /tmp/downloaded_packages/ /tmp/*.rds
+    rm -rf /var/lib/apt/lists/*
+%environment
+    export R_LIBS_USER="/usr/local/lib/R/site-library"

--- a/wave-utils/src/test/groovy/io/seqera/wave/util/CranHelperTest.groovy
+++ b/wave-utils/src/test/groovy/io/seqera/wave/util/CranHelperTest.groovy
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.wave.util
+
+import io.seqera.wave.config.CranOpts
+import spock.lang.Specification
+
+/**
+ * Test for CranHelper
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class CranHelperTest extends Specification {
+
+    def 'should trim a string' () {
+        expect:
+        CranHelper.trim0(STR) == EXPECTED
+
+        where:
+        STR         | EXPECTED
+        null        | null
+        "foo"       | "foo"
+        " foo  "    | "foo"
+        "'foo"      | "'foo"
+        '"foo'      | '"foo'
+        and:
+        "'foo'"     | "foo"
+        "''foo''"   | "foo"
+        " 'foo' "   | "foo"
+        " ' foo ' " | " foo "
+        and:
+        '"foo"'     | 'foo'
+        '""foo""'   | 'foo'
+    }
+
+    def 'should convert cran packages to list' () {
+        expect:
+        CranHelper.cranPackagesToList(PACKAGES) == EXPECTED
+
+        where:
+        PACKAGES         | EXPECTED
+        null             | null
+        ""               | null
+        "foo"            | ['foo']
+        "foo bar"        | ['foo', 'bar']
+        " foo   bar   "  | ['foo', 'bar']
+        "foo 'bar' baz"  | ['foo', 'bar', 'baz']
+        "foo \"bar\" baz"| ['foo', 'bar', 'baz']
+    }
+
+    def 'should create dockerfile for cran packages - complete test' () {
+        given:
+        def REPOSITORIES = ['cran', 'bioconductor']
+        def CRAN_OPTS = new CranOpts([rImage: 'rocker/r-ver:4.3.0', basePackages: 'build-essential'])
+        def PACKAGES = 'dplyr ggplot2 bioc::GenomicRanges'
+
+        when:
+        def result = CranHelper.cranPackagesToDockerFile(PACKAGES, REPOSITORIES, CRAN_OPTS)
+
+        then:
+        result == '''\
+            FROM rocker/r-ver:4.3.0
+            RUN \\
+                R -e "options(repos = c(CRAN = 'https://cloud.r-project.org/')); options(BioC_mirror = 'https://bioconductor.org')" \\
+                && apt-get update && apt-get install -y build-essential \\
+                && install2.r 'dplyr' 'ggplot2' BiocManager::install('GenomicRanges') \\
+                && rm -rf /tmp/downloaded_packages/ /tmp/*.rds \\
+                && rm -rf /var/lib/apt/lists/*
+            USER root
+            ENV R_LIBS_USER="/usr/local/lib/R/site-library"
+            '''.stripIndent()
+    }
+
+    def 'should create singularity file for cran packages - complete test' () {
+        given:
+        def REPOSITORIES = ['cran']
+        def CRAN_OPTS = new CranOpts([rImage: 'rocker/r-ver:4.4.1', basePackages: 'littler r-cran-docopt'])
+        def PACKAGES = 'tidyverse data.table'
+
+        when:
+        def result = CranHelper.cranPackagesToSingularityFile(PACKAGES, REPOSITORIES, CRAN_OPTS)
+
+        then:
+        result == '''\
+            BootStrap: docker
+            From: rocker/r-ver:4.4.1
+            %post
+                R -e "options(repos = c(CRAN = 'https://cloud.r-project.org/'))"
+                apt-get update && apt-get install -y littler r-cran-docopt
+                install2.r 'tidyverse' 'data.table'
+                rm -rf /tmp/downloaded_packages/ /tmp/*.rds
+                rm -rf /var/lib/apt/lists/*
+            %environment
+                export R_LIBS_USER="/usr/local/lib/R/site-library"
+            '''.stripIndent()
+    }
+
+    def 'should create dockerfile for cran file' () {
+        given:
+        def CRAN_OPTS = new CranOpts([rImage: 'rocker/r-ver:4.4.1'])
+
+        when:
+        def result = CranHelper.cranFileToDockerFile(CRAN_OPTS)
+
+        then:
+        result.contains('FROM rocker/r-ver:4.4.1')
+        result.contains('COPY --from=wave_context_dir . .')
+        result.contains('renv.lock')
+        result.contains('install.R')
+        result.contains('R_LIBS_USER="/usr/local/lib/R/site-library"')
+    }
+
+    def 'should create singularity file for cran file' () {
+        given:
+        def CRAN_OPTS = new CranOpts([rImage: 'rocker/r-ver:4.4.1', basePackages: 'build-essential'])
+
+        when:
+        def result = CranHelper.cranFileToSingularityFile(CRAN_OPTS)
+
+        then:
+        result.contains('BootStrap: docker')
+        result.contains('From: rocker/r-ver:4.4.1')
+        result.contains('%files')
+        result.contains('/opt/wave_context_dir')
+        result.contains('build-essential')
+        result.contains('renv.lock')
+        result.contains('export R_LIBS_USER="/usr/local/lib/R/site-library"')
+    }
+
+    def 'should handle empty packages' () {
+        given:
+        def CRAN_OPTS = new CranOpts([rImage: 'rocker/r-ver:4.4.1'])
+        def PACKAGES = ''
+
+        when:
+        def result = CranHelper.cranPackagesToDockerFile(PACKAGES, [], CRAN_OPTS)
+
+        then:
+        result.contains('FROM rocker/r-ver:4.4.1')
+        result.contains('install2.r')
+    }
+
+    def 'should handle remote renv.lock files' () {
+        given:
+        def CRAN_OPTS = new CranOpts([rImage: 'rocker/r-ver:4.4.1'])
+        def PACKAGES = 'https://example.com/renv.lock'
+
+        when:
+        def result = CranHelper.cranPackagesToDockerFile(PACKAGES, [], CRAN_OPTS)
+
+        then:
+        result.contains('https://example.com/renv.lock')
+    }
+
+    def 'should add custom commands' () {
+        given:
+        def CRAN_OPTS = new CranOpts([
+            rImage: 'rocker/r-ver:4.4.1',
+            commands: ['RUN echo "custom command"', 'RUN echo "another command"']
+        ])
+        def PACKAGES = 'dplyr'
+
+        when:
+        def dockerResult = CranHelper.cranPackagesToDockerFile(PACKAGES, [], CRAN_OPTS)
+        def singularityResult = CranHelper.cranPackagesToSingularityFile(PACKAGES, [], CRAN_OPTS)
+
+        then:
+        dockerResult.contains('RUN echo "custom command"')
+        dockerResult.contains('RUN echo "another command"')
+        singularityResult.contains('    RUN echo "custom command"')
+        singularityResult.contains('    RUN echo "another command"')
+    }
+
+    def 'should handle empty repositories list - complete dockerfile test' () {
+        given:
+        def CRAN_OPTS = new CranOpts([rImage: 'rocker/r-ver:4.4.1'])
+        def PACKAGES = 'shiny'
+
+        when:
+        def dockerResult = CranHelper.cranPackagesToDockerFile(PACKAGES, [], CRAN_OPTS)
+        def singularityResult = CranHelper.cranPackagesToSingularityFile(PACKAGES, [], CRAN_OPTS)
+
+        then:
+        dockerResult == '''\
+            FROM rocker/r-ver:4.4.1
+            RUN \\
+                R -e "options(repos = c(CRAN = 'https://cloud.r-project.org/'))" \\
+                && apt-get update && apt-get install -y littler r-cran-docopt \\
+                && install2.r 'shiny' \\
+                && rm -rf /tmp/downloaded_packages/ /tmp/*.rds \\
+                && rm -rf /var/lib/apt/lists/*
+            USER root
+            ENV R_LIBS_USER="/usr/local/lib/R/site-library"
+            '''.stripIndent()
+
+        singularityResult == '''\
+            BootStrap: docker
+            From: rocker/r-ver:4.4.1
+            %post
+                R -e "options(repos = c(CRAN = 'https://cloud.r-project.org/'))"
+                apt-get update && apt-get install -y littler r-cran-docopt
+                install2.r 'shiny'
+                rm -rf /tmp/downloaded_packages/ /tmp/*.rds
+                rm -rf /var/lib/apt/lists/*
+            %environment
+                export R_LIBS_USER="/usr/local/lib/R/site-library"
+            '''.stripIndent()
+    }
+
+    def 'should handle null base packages - complete test' () {
+        given:
+        def CRAN_OPTS = new CranOpts()
+        CRAN_OPTS.rImage = 'rocker/r-ver:4.4.1'
+        CRAN_OPTS.basePackages = null
+        def PACKAGES = 'dplyr'
+
+        when:
+        def dockerResult = CranHelper.cranPackagesToDockerFile(PACKAGES, ['cran'], CRAN_OPTS)
+        def singularityResult = CranHelper.cranPackagesToSingularityFile(PACKAGES, ['cran'], CRAN_OPTS)
+
+        then:
+        dockerResult == '''\
+            FROM rocker/r-ver:4.4.1
+            RUN \\
+                R -e "options(repos = c(CRAN = 'https://cloud.r-project.org/'))" \\
+                && install2.r 'dplyr' \\
+                && rm -rf /tmp/downloaded_packages/ /tmp/*.rds \\
+                && rm -rf /var/lib/apt/lists/*
+            USER root
+            ENV R_LIBS_USER="/usr/local/lib/R/site-library"
+            '''.stripIndent()
+
+        singularityResult == '''\
+            BootStrap: docker
+            From: rocker/r-ver:4.4.1
+            %post
+                R -e "options(repos = c(CRAN = 'https://cloud.r-project.org/'))"
+                install2.r 'dplyr'
+                rm -rf /tmp/downloaded_packages/ /tmp/*.rds
+                rm -rf /var/lib/apt/lists/*
+            %environment
+                export R_LIBS_USER="/usr/local/lib/R/site-library"
+            '''.stripIndent()
+    }
+
+    def 'should handle empty base packages string - complete test' () {
+        given:
+        def CRAN_OPTS = new CranOpts([rImage: 'rocker/r-ver:4.4.1', basePackages: ''])
+        def PACKAGES = 'ggplot2'
+
+        when:
+        def result = CranHelper.cranPackagesToDockerFile(PACKAGES, [], CRAN_OPTS)
+
+        then:
+        result == '''\
+            FROM rocker/r-ver:4.4.1
+            RUN \\
+                R -e "options(repos = c(CRAN = 'https://cloud.r-project.org/'))" \\
+                && install2.r 'ggplot2' \\
+                && rm -rf /tmp/downloaded_packages/ /tmp/*.rds \\
+                && rm -rf /var/lib/apt/lists/*
+            USER root
+            ENV R_LIBS_USER="/usr/local/lib/R/site-library"
+            '''.stripIndent()
+    }
+}


### PR DESCRIPTION
## Summary
- Add CRAN type to PackagesSpec enum for R package management support
- Implement CranOpts configuration class with customizable R image, base packages, and commands  
- Create CranHelper utility for generating Dockerfiles and Singularity files from CRAN packages
- Add template support for both explicit package lists and renv.lock/install.R files
- Include comprehensive test coverage for all CRAN functionality

## Test plan
- [x] Run existing tests to ensure no regressions
- [x] Add comprehensive unit tests for CranHelper utility
- [x] Test Dockerfile generation for CRAN packages
- [x] Test Singularity file generation for CRAN packages
- [x] Test integration with PackagesSpec

🤖 Generated with [Claude Code](https://claude.ai/code)