### PR TITLE
chore(lib-retry): upgrade failsafe 3.1.0 → 3.3.2

### DIFF
--- a/lib-httpx/build.gradle
+++ b/lib-httpx/build.gradle
@@ -25,7 +25,7 @@ version = "${project.file('VERSION').text.trim()}"
 dependencies {
     api project(':lib-retry')
     implementation 'com.google.code.gson:gson:2.10.1'
-    implementation 'dev.failsafe:failsafe:3.1.0'
+    implementation 'dev.failsafe:failsafe:3.3.2'
     
     testImplementation 'com.github.tomakehurst:wiremock:3.0.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/lib-httpx/src/main/java/io/seqera/http/HxConfig.java
+++ b/lib-httpx/src/main/java/io/seqera/http/HxConfig.java
@@ -20,8 +20,8 @@ package io.seqera.http;
 import java.net.CookiePolicy;
 import java.time.Duration;
 import java.util.Set;
-import java.util.function.Predicate;
 
+import dev.failsafe.function.CheckedPredicate;
 import io.seqera.http.auth.AuthenticationCallback;
 import io.seqera.util.retry.Retryable;
 
@@ -66,7 +66,7 @@ import io.seqera.util.retry.Retryable;
  */
 public class HxConfig implements Retryable.Config {
 
-    private static final Predicate<? extends Throwable> DEFAULT_RETRY_COND = throwable -> throwable instanceof java.io.IOException;
+    private static final CheckedPredicate<? extends Throwable> DEFAULT_RETRY_COND = throwable -> throwable instanceof java.io.IOException;
 
     private Duration delay = Duration.ofMillis(500);
     private Duration maxDelay = Duration.ofSeconds(30);
@@ -74,7 +74,7 @@ public class HxConfig implements Retryable.Config {
     private double jitter = 0.25d;
     private double multiplier = 2.0;
 
-    private Predicate<? extends Throwable> retryCondition = DEFAULT_RETRY_COND;
+    private CheckedPredicate<? extends Throwable> retryCondition = DEFAULT_RETRY_COND;
 
     private Set<Integer> retryStatusCodes = Set.of(429, 500, 502, 503, 504);
 
@@ -119,7 +119,7 @@ public class HxConfig implements Retryable.Config {
         return retryStatusCodes;
     }
 
-    public Predicate<? extends Throwable> getRetryCondition() {
+    public CheckedPredicate<? extends Throwable> getRetryCondition() {
         return retryCondition;
     }
 
@@ -176,7 +176,7 @@ public class HxConfig implements Retryable.Config {
         private int maxAttempts = 5;
         private double jitter = 0.25d;
         private double multiplier = 2.0;
-        private Predicate<? extends Throwable> retryCondition = DEFAULT_RETRY_COND;
+        private CheckedPredicate<? extends Throwable> retryCondition = DEFAULT_RETRY_COND;
         private Set<Integer> retryStatusCodes = Set.of(429, 500, 502, 503, 504);
         private String bearerToken;
         private String refreshToken;
@@ -293,16 +293,16 @@ public class HxConfig implements Retryable.Config {
          * @param condition the condition to determine if an exception should trigger a retry
          * @return this builder instance for method chaining
          */
-        public Builder retryCondition(Predicate<? extends Throwable> condition) {
+        public Builder retryCondition(CheckedPredicate<? extends Throwable> condition) {
             this.retryCondition = condition;
             return this;
         }
-        
+
         /**
-         * @deprecated Use {@link #retryCondition(Predicate)} instead. This method will be removed in a future version.
+         * @deprecated Use {@link #retryCondition(CheckedPredicate)} instead. This method will be removed in a future version.
          */
         @Deprecated(since = "2.1.0", forRemoval = true)
-        public Builder withRetryCondition(Predicate<? extends Throwable> condition) {
+        public Builder withRetryCondition(CheckedPredicate<? extends Throwable> condition) {
             this.retryCondition = condition;
             return this;
         }

--- a/lib-retry/build.gradle
+++ b/lib-retry/build.gradle
@@ -23,5 +23,5 @@ group = 'io.seqera'
 version = "${project.file('VERSION').text.trim()}"
 
 dependencies {
-    api 'dev.failsafe:failsafe:3.1.0'
+    api 'dev.failsafe:failsafe:3.3.2'
 }

--- a/lib-retry/src/main/java/io/seqera/util/retry/Retryable.java
+++ b/lib-retry/src/main/java/io/seqera/util/retry/Retryable.java
@@ -27,7 +27,6 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 
 import dev.failsafe.Failsafe;
 import dev.failsafe.FailsafeException;
@@ -36,6 +35,7 @@ import dev.failsafe.RetryPolicyBuilder;
 import dev.failsafe.event.EventListener;
 import dev.failsafe.event.ExecutionAttemptedEvent;
 import dev.failsafe.event.ExecutionCompletedEvent;
+import dev.failsafe.function.CheckedPredicate;
 import dev.failsafe.function.CheckedSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -257,13 +257,13 @@ public class Retryable<R> {
     public static final Duration DEFAULT_MAX_DELAY = Duration.ofSeconds(30);
     public static final int DEFAULT_MAX_ATTEMPTS = 5;
     public static final double DEFAULT_JITTER = 0.25d;
-    public static final Predicate<? extends Throwable> DEFAULT_CONDITION = e -> e instanceof IOException;
+    public static final CheckedPredicate<? extends Throwable> DEFAULT_CONDITION = e -> e instanceof IOException;
     public static final double DEFAULT_MULTIPLIER = 2.0;
 
     private Config config;
-    private Predicate<? extends Throwable> condition;
+    private CheckedPredicate<? extends Throwable> condition;
     private Consumer<Event<R>> retryEvent;
-    private Predicate<R> handleResult;
+    private CheckedPredicate<R> handleResult;
 
     public Retryable<R> withConfig(Config config) {
         this.config = new ConfigImpl(config);
@@ -274,12 +274,12 @@ public class Retryable<R> {
         return config;
     }
 
-    public Retryable<R> retryCondition(Predicate<? extends Throwable> cond) {
+    public Retryable<R> retryCondition(CheckedPredicate<? extends Throwable> cond) {
         this.condition = cond;
         return this;
     }
 
-    public Retryable<R> retryIf(Predicate<R> predicate) {
+    public Retryable<R> retryIf(CheckedPredicate<R> predicate) {
         this.handleResult = predicate;
         return this;
     }
@@ -294,7 +294,7 @@ public class Retryable<R> {
             @Override
             public void accept(ExecutionAttemptedEvent<R> event) throws Throwable {
                 if (retryEvent != null) {
-                    retryEvent.accept(new Event<>("Retry", event.getAttemptCount(), event.getLastResult(), event.getLastFailure()));
+                    retryEvent.accept(new Event<>("Retry", event.getAttemptCount(), event.getLastResult(), event.getLastException()));
                 }
                 // close the http response
                 if (event.getLastResult() instanceof HttpResponse<?>) {
@@ -307,7 +307,7 @@ public class Retryable<R> {
             @Override
             public void accept(ExecutionCompletedEvent<R> event) throws Throwable {
                 if (retryEvent != null) {
-                    retryEvent.accept(new Event<>("Failure", event.getAttemptCount(), event.getResult(), event.getFailure()));
+                    retryEvent.accept(new Event<>("Failure", event.getAttemptCount(), event.getResult(), event.getException()));
                 }
             }
         };


### PR DESCRIPTION
## Summary

- Bump `dev.failsafe:failsafe` from `3.1.0` to `3.3.2` in `lib-retry/build.gradle`.
- Replace removed `getLastFailure()` / `getFailure()` calls with `getLastException()` / `getException()` on event objects (breaking change in 3.3.0).
- Change `condition`, `handleResult` fields and public `retryCondition` / `retryIf` method signatures from `java.util.function.Predicate` to `dev.failsafe.function.CheckedPredicate`, as required by `handleIf` / `handleResultIf` since 3.2.1.

## Test plan

- [x] `./gradlew :lib-retry:test` passes with no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)