### PR TITLE
docs(lib-cmd-queue-redis): document the 0.4.0 metrics constructor

### DIFF
--- a/lib-cmd-queue-redis/README.md
+++ b/lib-cmd-queue-redis/README.md
@@ -8,7 +8,7 @@ Add this dependency to your `build.gradle`:
 
 ```gradle
 dependencies {
-    implementation 'io.seqera:lib-cmd-queue-redis:0.1.0'
+    implementation 'io.seqera:lib-cmd-queue-redis:0.4.0'
 }
 ```
 
@@ -117,6 +117,38 @@ ProcessingResult result = commandService.getResult(commandId, ProcessingResult.c
 // Stop consuming commands (e.g. during shutdown)
 commandService.stop();
 ```
+
+## Metrics (optional)
+
+Since `0.4.0`, `CommandQueue` exposes a second constructor that forwards an optional
+[`StreamMetrics`](https://github.com/seqeralabs/libseqera/tree/master/lib-data-stream-redis)
+handle to the underlying `AbstractMessageStream`. Subclasses that want to publish
+Micrometer metrics construct a `MicrometerStreamMetrics` from a `MeterRegistry` and pass
+it through:
+
+```java
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micronaut.core.annotation.Nullable;
+import io.seqera.data.stream.metrics.MicrometerStreamMetrics;
+
+public class MyCommandQueue extends CommandQueue {
+
+    @Inject
+    public MyCommandQueue(MessageStream<String> target, @Nullable MeterRegistry registry) {
+        super(target, registry != null
+                ? new MicrometerStreamMetrics(registry, "my-cmd-queue")
+                : null);
+    }
+
+    @Override protected String name() { return "my-cmd-queue"; }
+    @Override protected Duration pollInterval() { return Duration.ofSeconds(1); }
+}
+```
+
+The 1-arg constructor is unchanged: existing subclasses continue to compile and run
+with no metrics. See [`lib-data-stream-redis`](../lib-data-stream-redis/README.md) for the
+list of published meters (`seqera.stream.entries`, `seqera.stream.messages`,
+`seqera.stream.processing`) and their tags.
 
 ## Command Status Flow
 


### PR DESCRIPTION
## Summary

Follow-up to #70. The `lib-cmd-queue-redis` README still showed the `0.1.0` install snippet and didn't mention the new metrics-aware constructor added in `0.4.0`.

- Bumps the install snippet from `0.1.0` to `0.4.0`.
- Adds a Metrics section showing how a subclass forwards a Micrometer `MeterRegistry` into the new `(MessageStream, StreamMetrics)` constructor, with a pointer to `lib-data-stream-redis` for the full meter list and PromQL recipes.

## Test plan

- [x] README renders correctly (no broken links, code block valid).
- [x] No code changes; existing tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)