### PR TITLE
feat(lib-retry, lib-httpx): honor server-supplied Retry-After on retries

### DIFF
--- a/lib-httpx/src/main/java/io/seqera/http/HxClient.java
+++ b/lib-httpx/src/main/java/io/seqera/http/HxClient.java
@@ -476,6 +476,7 @@ public class HxClient {
         final Retryable<HttpResponse<T>> retry = Retryable.<HttpResponse<T>>of(config)
                 .retryCondition(config.getRetryCondition())
                 .retryIf(this::shouldRetryOnResponse)
+                .retryDelayHint(HxClient::parseRetryAfter)
                 .onRetry(event -> {
                     String message = event.getFailure() != null ? event.getFailure().getMessage()
                             : String.valueOf(event.getResult().statusCode());
@@ -548,6 +549,7 @@ public class HxClient {
         final Retryable<HttpResponse<T>> retry = Retryable.<HttpResponse<T>>of(config)
                 .retryCondition(config.getRetryCondition())
                 .retryIf(this::shouldRetryOnResponse)
+                .retryDelayHint(HxClient::parseRetryAfter)
                 .onRetry(event -> {
                     String message = event.getFailure() != null ? event.getFailure().getMessage()
                             : String.valueOf(event.getResult().statusCode());
@@ -637,6 +639,39 @@ public class HxClient {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Extracts the {@code Retry-After} header from an HTTP response as a {@link Duration},
+     * for use as a per-attempt delay hint by the retry policy. Returns {@code null} when the
+     * header is absent or malformed, in which case the regular backoff schedule applies.
+     *
+     * <p>Only the RFC 9110 §10.2.3 delta-seconds form is supported (e.g. {@code Retry-After: 41});
+     * the HTTP-date form is not used by Seqera services and is intentionally ignored to keep
+     * parsing trivial. The retry policy uses this as a lower bound — see
+     * {@link Retryable#retryDelayHint(java.util.function.Function)}.
+     *
+     * @param response the HTTP response to inspect; may be null
+     * @return the requested wait duration, or null if no usable hint is present
+     */
+    static Duration parseRetryAfter(HttpResponse<?> response) {
+        if (response == null) {
+            return null;
+        }
+        final String header = response.headers().firstValue("retry-after").orElse(null);
+        if (header == null) {
+            return null;
+        }
+        try {
+            final long secs = Long.parseLong(header.trim());
+            if (secs <= 0) {
+                return null;
+            }
+            return Duration.ofSeconds(secs);
+        }
+        catch (NumberFormatException e) {
+            return null;
+        }
     }
 
     public HttpClient getHttpClient() {

--- a/lib-httpx/src/test/groovy/io/seqera/http/HxClientRetryIntegrationTest.groovy
+++ b/lib-httpx/src/test/groovy/io/seqera/http/HxClientRetryIntegrationTest.groovy
@@ -144,9 +144,12 @@ class HxClientRetryIntegrationTest extends Specification {
 
     def 'should retry on 429 rate limit'() {
         given:
+        // Cap maxDelay so the server-supplied Retry-After: 1 is bounded — this test verifies
+        // the retry mechanic in general, not Retry-After honoring (covered separately below).
         def config = HxConfig.newBuilder()
                 .withMaxAttempts(3)
                 .withDelay(Duration.ofMillis(100))
+                .withMaxDelay(Duration.ofMillis(200))
                 .build()
         def client = HxClient.newBuilder().config(config).build()
 
@@ -414,5 +417,145 @@ class HxClientRetryIntegrationTest extends Specification {
 
         and: 'all 3 attempts should be made'
         wireMockServer.verify(3, getRequestedFor(urlEqualTo('/api/persistent-io-error-async')))
+    }
+
+    def 'should honour Retry-After header on 429 as a delay lower bound'() {
+        given: 'fast backoff (50ms) but server requests a 1s wait via Retry-After'
+        def config = HxConfig.newBuilder()
+                .withMaxAttempts(3)
+                .withDelay(Duration.ofMillis(50))
+                .withMaxDelay(Duration.ofSeconds(5))
+                .build()
+        def client = HxClient.newBuilder().config(config).build()
+
+        and: 'server returns 429 with Retry-After: 1, then 200'
+        wireMockServer.stubFor(get(urlEqualTo('/api/rate-limited'))
+                .inScenario('retry-after')
+                .whenScenarioStateIs('Started')
+                .willReturn(aResponse()
+                        .withStatus(429)
+                        .withHeader('Retry-After', '1')
+                        .withBody('{"type":"TOO_MANY_REQUESTS"}'))
+                .willSetStateTo('hint-honored'))
+
+        wireMockServer.stubFor(get(urlEqualTo('/api/rate-limited'))
+                .inScenario('retry-after')
+                .whenScenarioStateIs('hint-honored')
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody('OK')))
+
+        and:
+        def request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:${wireMockServer.port()}/api/rate-limited"))
+                .GET()
+                .build()
+
+        when:
+        def t0 = System.currentTimeMillis()
+        def response = client.send(request, HttpResponse.BodyHandlers.ofString())
+        def elapsed = System.currentTimeMillis() - t0
+
+        then:
+        response.statusCode() == 200
+        response.body() == 'OK'
+
+        and: '2 attempts were made'
+        wireMockServer.verify(2, getRequestedFor(urlEqualTo('/api/rate-limited')))
+
+        and: 'the retry honoured Retry-After (~1s), not the 50ms backoff (allow 25% jitter)'
+        elapsed >= 750
+    }
+
+    def 'async send honours Retry-After header on 429'() {
+        given: 'fast backoff but server requests a 1s wait via Retry-After'
+        def config = HxConfig.newBuilder()
+                .withMaxAttempts(3)
+                .withDelay(Duration.ofMillis(50))
+                .withMaxDelay(Duration.ofSeconds(5))
+                .build()
+        def client = HxClient.newBuilder().config(config).build()
+
+        and: 'server returns 429 with Retry-After: 1, then 200'
+        wireMockServer.stubFor(get(urlEqualTo('/api/rate-limited-async'))
+                .inScenario('retry-after-async')
+                .whenScenarioStateIs('Started')
+                .willReturn(aResponse()
+                        .withStatus(429)
+                        .withHeader('Retry-After', '1')
+                        .withBody('Too Many Requests'))
+                .willSetStateTo('hint-honored'))
+
+        wireMockServer.stubFor(get(urlEqualTo('/api/rate-limited-async'))
+                .inScenario('retry-after-async')
+                .whenScenarioStateIs('hint-honored')
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody('OK')))
+
+        and:
+        def request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:${wireMockServer.port()}/api/rate-limited-async"))
+                .GET()
+                .build()
+
+        when:
+        def t0 = System.currentTimeMillis()
+        def response = client.sendAsync(request, HttpResponse.BodyHandlers.ofString()).get()
+        def elapsed = System.currentTimeMillis() - t0
+
+        then:
+        response.statusCode() == 200
+        response.body() == 'OK'
+
+        and: '2 attempts were made'
+        wireMockServer.verify(2, getRequestedFor(urlEqualTo('/api/rate-limited-async')))
+
+        and: 'the async retry honoured Retry-After (~1s ± 25% jitter), not the 50ms backoff'
+        elapsed >= 750
+    }
+
+    def 'Retry-After is capped by the configured maxDelay'() {
+        given: 'maxDelay (300ms) much smaller than the server-supplied Retry-After (10s)'
+        def config = HxConfig.newBuilder()
+                .withMaxAttempts(2)
+                .withDelay(Duration.ofMillis(50))
+                .withMaxDelay(Duration.ofMillis(300))
+                .build()
+        def client = HxClient.newBuilder().config(config).build()
+
+        and: 'server returns 429 with an aggressive Retry-After'
+        wireMockServer.stubFor(get(urlEqualTo('/api/rate-limited-capped'))
+                .inScenario('retry-after-capped')
+                .whenScenarioStateIs('Started')
+                .willReturn(aResponse()
+                        .withStatus(429)
+                        .withHeader('Retry-After', '10')   // 10s — far exceeds maxDelay
+                        .withBody('Too Many Requests'))
+                .willSetStateTo('done'))
+
+        wireMockServer.stubFor(get(urlEqualTo('/api/rate-limited-capped'))
+                .inScenario('retry-after-capped')
+                .whenScenarioStateIs('done')
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody('OK')))
+
+        and:
+        def request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:${wireMockServer.port()}/api/rate-limited-capped"))
+                .GET()
+                .build()
+
+        when:
+        def t0 = System.currentTimeMillis()
+        def response = client.send(request, HttpResponse.BodyHandlers.ofString())
+        def elapsed = System.currentTimeMillis() - t0
+
+        then:
+        response.statusCode() == 200
+
+        and: 'wait was bounded by maxDelay (300ms ± 25% jitter), never the 10s hint'
+        elapsed < 2000
     }
 }

--- a/lib-httpx/src/test/groovy/io/seqera/http/HxClientTest.groovy
+++ b/lib-httpx/src/test/groovy/io/seqera/http/HxClientTest.groovy
@@ -395,4 +395,40 @@ class HxClientTest extends Specification {
         then:
         client.tokenManager.tokenStore == customStore
     }
+
+    def 'parseRetryAfter returns null for null response'() {
+        expect:
+        HxClient.parseRetryAfter(null) == null
+    }
+
+    def 'parseRetryAfter parses delta-seconds and rejects malformed/non-positive values'() {
+        given:
+        def httpHeaders = java.net.http.HttpHeaders.of(headers, { a, b -> true })
+        and: 'a minimal HttpResponse exposing only the headers — HttpHeaders is final so Spock cannot mock it directly'
+        def response = new HttpResponse() {
+            int statusCode() { 0 }
+            HttpRequest request() { null }
+            Optional<HttpResponse<?>> previousResponse() { Optional.empty() }
+            java.net.http.HttpHeaders headers() { httpHeaders }
+            Object body() { null }
+            Optional<javax.net.ssl.SSLSession> sslSession() { Optional.empty() }
+            URI uri() { null }
+            HttpClient.Version version() { HttpClient.Version.HTTP_1_1 }
+        }
+
+        expect:
+        HxClient.parseRetryAfter(response) == expected
+
+        where:
+        headers                                            | expected
+        ['retry-after': ['41']]                            | Duration.ofSeconds(41)
+        ['retry-after': ['  41  ']]                        | Duration.ofSeconds(41)   // whitespace trimmed
+        ['retry-after': ['1']]                             | Duration.ofSeconds(1)
+        ['retry-after': ['0']]                             | null                     // zero is not a useful hint
+        ['retry-after': ['-5']]                            | null                     // negative rejected
+        ['retry-after': ['abc']]                           | null                     // non-numeric
+        ['retry-after': ['1.5']]                           | null                     // fractional not supported
+        ['retry-after': ['Wed, 21 Oct 2015 07:28:00 GMT']] | null                     // HTTP-date form not supported
+        [:]                                                | null                     // header absent
+    }
 }

--- a/lib-retry/src/main/java/io/seqera/util/retry/Retryable.java
+++ b/lib-retry/src/main/java/io/seqera/util/retry/Retryable.java
@@ -334,12 +334,9 @@ public class Retryable<R> {
             }
         };
 
-        final Duration initialDelay = config.getDelayAsDuration();
-        final Duration maxDelay = config.getMaxDelayAsDuration();
-        final double multiplier = config.getMultiplier();
-
         final RetryPolicyBuilder<R> policy = RetryPolicy.<R>builder()
                 .handleIf(toChecked(condition != null ? condition : DEFAULT_CONDITION))
+                .withBackoff(config.getDelayAsDuration(), config.getMaxDelayAsDuration(), config.getMultiplier())
                 .withMaxAttempts(config.getMaxAttempts())
                 .withJitter(config.getJitter())
                 .onRetry(retry0)
@@ -349,11 +346,11 @@ public class Retryable<R> {
             // The hint (e.g. HTTP Retry-After) is a lower bound: we never wait less than the
             // server asked, and never less than the scheduled exponential backoff. The result
             // is capped by maxDelay to honor the local config contract. Failsafe still applies
-            // jitter on top of the value returned here.
-            //
-            // Note: withDelayFn replaces withBackoff entirely (they're mutually exclusive in
-            // Failsafe), so we must compute the exponential backoff manually here — when the
-            // hint resolves to null, the lambda still returns a value derived from the schedule.
+            // jitter on top of the value returned here, and uses withDelayFn in preference to
+            // the withBackoff schedule when both are set.
+            final Duration initialDelay = config.getDelayAsDuration();
+            final Duration maxDelay = config.getMaxDelayAsDuration();
+            final double multiplier = config.getMultiplier();
             policy.withDelayFn(ctx -> {
                 final Duration backoff = computeBackoff(initialDelay, maxDelay, multiplier, ctx.getAttemptCount());
                 Duration hint = null;
@@ -368,9 +365,6 @@ public class Retryable<R> {
                 Duration base = (hint != null && hint.compareTo(backoff) > 0) ? hint : backoff;
                 return base.compareTo(maxDelay) > 0 ? maxDelay : base;
             });
-        }
-        else {
-            policy.withBackoff(initialDelay, maxDelay, multiplier);
         }
 
         if (handleResult != null) {

--- a/lib-retry/src/main/java/io/seqera/util/retry/Retryable.java
+++ b/lib-retry/src/main/java/io/seqera/util/retry/Retryable.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import dev.failsafe.Failsafe;
@@ -265,6 +266,7 @@ public class Retryable<R> {
     private Predicate<? extends Throwable> condition;
     private Consumer<Event<R>> retryEvent;
     private Predicate<R> handleResult;
+    private Function<R, Duration> delayHint;
 
     public Retryable<R> withConfig(Config config) {
         this.config = new ConfigImpl(config);
@@ -287,6 +289,25 @@ public class Retryable<R> {
 
     public Retryable<R> onRetry(Consumer<Event<R>> event) {
         this.retryEvent = event;
+        return this;
+    }
+
+    /**
+     * Registers a function that extracts a per-attempt delay hint from the last result.
+     *
+     * <p>When set, the delay before the next retry is {@code max(scheduled_backoff, hint)},
+     * capped by the configured {@code maxDelay}. Jitter is still applied on top. This is the
+     * mechanism used to honor server-supplied {@code Retry-After} headers for HTTP 429/503
+     * responses while not retrying any sooner than the local backoff schedule would.
+     *
+     * <p>The function may return {@code null} (or throw, which is logged and ignored) for
+     * attempts where no hint is available; in that case the regular backoff applies.
+     *
+     * @param fn extractor returning a lower-bound delay derived from the just-failed result
+     * @return this builder
+     */
+    public Retryable<R> retryDelayHint(Function<R, Duration> fn) {
+        this.delayHint = fn;
         return this;
     }
 
@@ -313,18 +334,71 @@ public class Retryable<R> {
             }
         };
 
+        final Duration initialDelay = config.getDelayAsDuration();
+        final Duration maxDelay = config.getMaxDelayAsDuration();
+        final double multiplier = config.getMultiplier();
+
         final RetryPolicyBuilder<R> policy = RetryPolicy.<R>builder()
                 .handleIf(toChecked(condition != null ? condition : DEFAULT_CONDITION))
-                .withBackoff(config.getDelayAsDuration(), config.getMaxDelayAsDuration(), config.getMultiplier())
                 .withMaxAttempts(config.getMaxAttempts())
                 .withJitter(config.getJitter())
                 .onRetry(retry0)
                 .onFailure(failure0);
 
+        if (delayHint != null) {
+            // The hint (e.g. HTTP Retry-After) is a lower bound: we never wait less than the
+            // server asked, and never less than the scheduled exponential backoff. The result
+            // is capped by maxDelay to honor the local config contract. Failsafe still applies
+            // jitter on top of the value returned here.
+            //
+            // Note: withDelayFn replaces withBackoff entirely (they're mutually exclusive in
+            // Failsafe), so we must compute the exponential backoff manually here — when the
+            // hint resolves to null, the lambda still returns a value derived from the schedule.
+            policy.withDelayFn(ctx -> {
+                final Duration backoff = computeBackoff(initialDelay, maxDelay, multiplier, ctx.getAttemptCount());
+                Duration hint = null;
+                final R last = ctx.getLastResult();
+                if (last != null) {
+                    try {
+                        hint = delayHint.apply(last);
+                    } catch (Exception e) {
+                        log.debug("Retry delay hint extractor failed", e);
+                    }
+                }
+                Duration base = (hint != null && hint.compareTo(backoff) > 0) ? hint : backoff;
+                return base.compareTo(maxDelay) > 0 ? maxDelay : base;
+            });
+        }
+        else {
+            policy.withBackoff(initialDelay, maxDelay, multiplier);
+        }
+
         if (handleResult != null) {
             policy.handleResultIf(handleResult::test);
         }
         return policy.build();
+    }
+
+    /**
+     * Computes the scheduled exponential backoff for the next retry attempt, mirroring the
+     * Failsafe {@code withBackoff} semantics: {@code initial * multiplier^(attempt-1)}, capped
+     * by {@code maxDelay}. Used when a custom {@code withDelayFn} is installed and needs to
+     * combine the schedule with an external hint.
+     *
+     * @param initial   the initial delay (first retry uses this exact value)
+     * @param maxDelay  the upper bound for any single retry delay
+     * @param factor    the exponential growth factor
+     * @param attempt   1-based count of failed attempts so far (= index of the upcoming retry)
+     */
+    private static Duration computeBackoff(Duration initial, Duration maxDelay, double factor, int attempt) {
+        if (attempt <= 1) {
+            return initial;
+        }
+        final double millis = initial.toMillis() * Math.pow(factor, attempt - 1);
+        if (millis >= maxDelay.toMillis()) {
+            return maxDelay;
+        }
+        return Duration.ofMillis((long) millis);
     }
 
     // Adapt a java.util.function.Predicate to failsafe's CheckedPredicate, which

--- a/lib-retry/src/main/java/io/seqera/util/retry/Retryable.java
+++ b/lib-retry/src/main/java/io/seqera/util/retry/Retryable.java
@@ -30,6 +30,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import dev.failsafe.ExecutionContext;
 import dev.failsafe.Failsafe;
 import dev.failsafe.FailsafeException;
 import dev.failsafe.RetryPolicy;
@@ -343,34 +344,48 @@ public class Retryable<R> {
                 .onFailure(failure0);
 
         if (delayHint != null) {
-            // The hint (e.g. HTTP Retry-After) is a lower bound: we never wait less than the
-            // server asked, and never less than the scheduled exponential backoff. The result
-            // is capped by maxDelay to honor the local config contract. Failsafe still applies
-            // jitter on top of the value returned here, and uses withDelayFn in preference to
-            // the withBackoff schedule when both are set.
+            // Failsafe uses withDelayFn in preference to the withBackoff schedule when both are
+            // set, and still applies jitter on top. See computeRetryDelay for the semantics.
             final Duration initialDelay = config.getDelayAsDuration();
             final Duration maxDelay = config.getMaxDelayAsDuration();
             final double multiplier = config.getMultiplier();
-            policy.withDelayFn(ctx -> {
-                final Duration backoff = computeBackoff(initialDelay, maxDelay, multiplier, ctx.getAttemptCount());
-                Duration hint = null;
-                final R last = ctx.getLastResult();
-                if (last != null) {
-                    try {
-                        hint = delayHint.apply(last);
-                    } catch (Exception e) {
-                        log.debug("Retry delay hint extractor failed", e);
-                    }
-                }
-                Duration base = (hint != null && hint.compareTo(backoff) > 0) ? hint : backoff;
-                return base.compareTo(maxDelay) > 0 ? maxDelay : base;
-            });
+            policy.withDelayFn(ctx -> computeRetryDelay(ctx, initialDelay, maxDelay, multiplier, delayHint));
         }
 
         if (handleResult != null) {
             policy.handleResultIf(handleResult::test);
         }
         return policy.build();
+    }
+
+    /**
+     * Computes the next retry delay as {@code min(maxDelay, max(scheduledBackoff, hint))}.
+     *
+     * <p>The hint extracted from the just-failed result (e.g. an HTTP {@code Retry-After}
+     * header) acts as a strict lower bound — never wait less than the server asked. The
+     * scheduled exponential backoff is the alternative lower bound — never wait less than the
+     * normal retry schedule. The configured {@code maxDelay} caps both. If the extractor
+     * returns {@code null} (or throws, which is logged and treated as null), the result
+     * falls back to the scheduled backoff.
+     */
+    private static <R> Duration computeRetryDelay(
+            ExecutionContext<R> ctx,
+            Duration initialDelay,
+            Duration maxDelay,
+            double multiplier,
+            Function<R, Duration> delayHint) {
+        final Duration backoff = computeBackoff(initialDelay, maxDelay, multiplier, ctx.getAttemptCount());
+        Duration hint = null;
+        final R last = ctx.getLastResult();
+        if (last != null) {
+            try {
+                hint = delayHint.apply(last);
+            } catch (Exception e) {
+                log.debug("Retry delay hint extractor failed", e);
+            }
+        }
+        final Duration base = (hint != null && hint.compareTo(backoff) > 0) ? hint : backoff;
+        return base.compareTo(maxDelay) > 0 ? maxDelay : base;
     }
 
     /**

--- a/lib-retry/src/test/groovy/io/seqera/util/retry/RetryableTest.groovy
+++ b/lib-retry/src/test/groovy/io/seqera/util/retry/RetryableTest.groovy
@@ -138,6 +138,99 @@ class RetryableTest extends Specification {
         e.message == 'Oops failed!'
     }
 
+    // Note: ConfigImpl substitutes DEFAULT_JITTER (0.25) whenever getJitter() returns 0.0,
+    // so these tests implicitly run with 25% jitter applied by Failsafe on top of the
+    // computed delay. Assertions allow for this variance.
+
+    def 'retryDelayHint floors the wait at the hinted value when greater than backoff'() {
+        given: 'a fast backoff (50ms) and a hint of 600ms'
+        def config = Mock(Retryable.Config) {
+            getDelay() >> Duration.ofMillis(50)
+            getMaxDelay() >> Duration.ofSeconds(5)
+            getMaxAttempts() >> 3
+            getMultiplier() >> 2.0
+        }
+        and: 'a value-returning supplier that fails twice then succeeds'
+        int attempts = 0
+        def timestamps = []
+        def retryable = Retryable.<String>of(config)
+                .retryIf { it == 'TRY_AGAIN' }
+                .retryDelayHint { result -> result == 'TRY_AGAIN' ? Duration.ofMillis(600) : null }
+
+        when:
+        def start = System.currentTimeMillis()
+        def result = retryable.apply {
+            timestamps << (System.currentTimeMillis() - start)
+            attempts++
+            return attempts < 3 ? 'TRY_AGAIN' : 'OK'
+        }
+
+        then:
+        result == 'OK'
+        attempts == 3
+        // each retry waits hint=600ms ± 25% jitter (450..750), well above the 50/100ms backoff
+        (timestamps[1] - timestamps[0]) >= 450
+        (timestamps[2] - timestamps[1]) >= 450
+    }
+
+    def 'retryDelayHint falls back to backoff when hint is null'() {
+        given:
+        def config = Mock(Retryable.Config) {
+            getDelay() >> Duration.ofMillis(50)
+            getMaxDelay() >> Duration.ofSeconds(5)
+            getMaxAttempts() >> 3
+            getMultiplier() >> 2.0
+        }
+        and:
+        int attempts = 0
+        def timestamps = []
+        def retryable = Retryable.<String>of(config)
+                .retryIf { it == 'TRY_AGAIN' }
+                .retryDelayHint { result -> null } // no hint - regular backoff applies
+
+        when:
+        def start = System.currentTimeMillis()
+        retryable.apply {
+            timestamps << (System.currentTimeMillis() - start)
+            attempts++
+            return attempts < 3 ? 'TRY_AGAIN' : 'OK'
+        }
+
+        then:
+        // first retry uses backoff 50ms ± 25% (37..62), second uses 100ms ± 25% (75..125)
+        (timestamps[1] - timestamps[0]) < 200   // well below any reasonable hint
+        (timestamps[2] - timestamps[1]) < 300
+    }
+
+    def 'retryDelayHint is capped by maxDelay'() {
+        given: 'maxDelay (200ms) smaller than the hint (10s)'
+        def config = Mock(Retryable.Config) {
+            getDelay() >> Duration.ofMillis(50)
+            getMaxDelay() >> Duration.ofMillis(200)
+            getMaxAttempts() >> 2
+            getMultiplier() >> 2.0
+        }
+        and:
+        int attempts = 0
+        def timestamps = []
+        def retryable = Retryable.<String>of(config)
+                .retryIf { it == 'TRY_AGAIN' }
+                .retryDelayHint { result -> Duration.ofSeconds(10) }  // huge hint
+
+        when:
+        def start = System.currentTimeMillis()
+        retryable.apply {
+            timestamps << (System.currentTimeMillis() - start)
+            attempts++
+            return attempts < 2 ? 'TRY_AGAIN' : 'OK'
+        }
+
+        then:
+        attempts == 2
+        // wait must respect maxDelay (200ms ± 25% → max ~250ms) - never the 10s the hint asked for
+        (timestamps[1] - timestamps[0]) < 500
+    }
+
     def 'should validate config' () {
         given:
         def config = Mock(Retryable.Config){


### PR DESCRIPTION
## Summary

Adds server-driven retry timing to the HTTP retry pipeline so callers automatically honor `Retry-After` headers on 429/503 responses, instead of running their own (typically much shorter) exponential backoff inside the server rate-limit window.

- **`lib-retry`**: new generic builder hook `Retryable.retryDelayHint(Function<R, Duration>)`. When set, the policy waits `min(maxDelay, max(scheduled_backoff, hint))`. The hint is a strict lower bound, the configured `maxDelay` is a strict upper bound, and Failsafe `withJitter` continues to apply on top. A `null` hint falls back to the regular exponential backoff — fully backward-compatible for callers that do not opt in.
- **`lib-httpx`**: both `sendWithRetry` and `sendWithRetryAsync` now wire `HxClient::parseRetryAfter` as the hint extractor. Only the RFC 9110 §10.2.3 delta-seconds form is parsed (e.g. `Retry-After: 41`); HTTP-date form degrades to backoff (not used by Seqera services).

### Motivation

Nextflow issue [nextflow-io/nextflow#7176](https://github.com/nextflow-io/nextflow/issues/7176): the plugin registry returns `429 + Retry-After: 41` under burst CI load, but the HxClient generic exponential backoff (5 attempts ~5.6s total wait) lands every retry inside the same 60-second rate-limit window and they all fail. Honoring `Retry-After` at the library layer fixes this for every Seqera HTTP caller — Wave, Tower, registry — not just plugin metadata.

### Design notes

- `withDelayFn` and `withBackoff` are mutually exclusive in Failsafe 3.3.2, so when a hint extractor is registered we compute exponential backoff manually inside the lambda. `maxDelay` is also enforced manually because `withDelayFn` does not honor the policy `maxDelay` field.
- Failsafe rethrows exceptions from `delayFn`, so the hint extractor invocation is wrapped in try/catch — a misbehaving extractor degrades to backoff rather than breaking the retry.
- Async parity verified with a wiremock test that uses `sendAsync(...).get()`.

## Test plan

- [x] `:lib-retry:test` — 3 new Spock tests for `retryDelayHint`: floor (hint > backoff), fallback (null hint), cap (hint > maxDelay)
- [x] `:lib-httpx:test` — 2 new wiremock integration tests (sync and async 429 + `Retry-After` honored as lower bound), 1 new wiremock test for the `maxDelay` cap, and 9-row data-driven unit test for `parseRetryAfter` edge cases (null response, whitespace, zero, negative, non-numeric, fractional, HTTP-date, missing header)
- [x] No regressions in the existing `HxClientRetryIntegrationTest`, `HxClientTest`, and `RetryableTest` suites
- [x] The pre-existing `should retry on 429 rate limit` integration test pins a small `maxDelay` so it stays fast under the new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
