### PR TITLE
Add async worker-pool processing to lib-cmd-queue-redis

### DIFF
--- a/docs/superpowers/specs/2026-07-01-async-command-processing-design.md
+++ b/docs/superpowers/specs/2026-07-01-async-command-processing-design.md
@@ -1,0 +1,336 @@
+# Async command processing for `lib-cmd-queue-redis` — Approach A
+
+**Date:** 2026-07-01
+**Module:** `lib-cmd-queue-redis` (current v0.4.0)
+**Status:** approved for implementation (revised after adversarial spec review)
+
+## 1. Problem
+
+Today the command queue processes messages **serially on a single poll thread**.
+`AbstractMessageStream.processMessages()` loops over each registered stream and calls
+`RedisMessageStream.consume()`, which runs the consumer **synchronously** and blocks the
+poll thread. `CommandServiceImpl` submits `handler.execute()` to the shared blocking
+executor but then **waits up to `executeTimeout` (default 1s)** for it
+(`executeWithTimeout`). Net effect: throughput ≈ one command at a time per replica, and
+each command occupies the poll thread for up to the timeout.
+
+Long-running work is handled indirectly: on timeout the overrun `execute()` future's
+result is **discarded**, the command is marked `RUNNING`, and on redelivery the handler's
+`checkStatus()` is polled until terminal. This assumes the real work lives **outside** our
+threads (an external job the handler polls).
+
+**Goal:** run command handlers to completion on a **bounded worker pool** so multiple
+commands execute concurrently and the poll thread never blocks on a handler — while
+guaranteeing that a given command's `execute()` is **not run concurrently on more than one
+replica** ("exactly-once-ish": single concurrent runner, at-least-once on crash) — and
+**without breaking** the existing `execute()`/`checkStatus()` external-job pattern.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- Poll thread dispatches each message to a bounded pool and returns immediately (non-blocking).
+- Handlers may block for arbitrarily long on a worker thread (in-process pattern); `checkStatus()` stays supported (external-job pattern).
+- No concurrent double-execution of the same command across replicas; automatic recovery if a replica dies.
+- Backpressure: bounded pool refuses excess work; refused messages stay in the queue.
+- **No change to the shared `lib-data-stream-redis` interface.**
+- Backward compatible: existing `CommandHandler`/`CommandConfig`/`CommandService`/`CommandRegistration` consumers keep working, and existing tests keep passing.
+
+**Non-goals**
+- No change to `MessageStream` / `AbstractMessageStream` / `RedisMessageStream` / `LocalMessageStream`.
+- No new ack/renew primitive on the stream (that is Approach B — out of scope).
+- No ordering guarantees beyond what Redis Streams already provide.
+- No interruption of a running handler on `cancel()` (cancel is advisory — see §5).
+
+## 3. The two deliberate simplifications
+
+| # | Shortcut | Taken here? |
+|---|----------|-------------|
+| 1 | Poll thread **waits ~5s** for the handler, then offloads (the "Future + 5s" two-tier) | **NOT taken.** Dispatch is fully non-blocking: every command is offloaded to the pool immediately, so there is nothing to "wait 5s then move." The 5s threshold from the original sketch is superseded. |
+| 2 | Worker **does not ack**; the finished entry is acked later, on the next reclaim, when the store shows a terminal state | **TAKEN.** This is the only place `true` is returned to the stream, so the only place `XACK`+`XDEL` happens. Keeps the stream interface untouched. |
+
+### Simplification #2 in detail (the ack path)
+
+`RedisMessageStream.consume()` acks (`XACK`+`XDEL`) **only** when the consumer returns
+`true`. During execution the poll thread returns `false`, so the entry stays **unacked** in
+the pending-entries list (PEL). The worker, on completion, writes the terminal state to the
+**store** — it never touches the stream. The entry is removed only when a later poll cycle
+**reclaims** it (`XAUTOCLAIM`, once idle > `claimTimeout`) and the consumer, seeing a
+terminal state, returns `true`.
+
+Consequence — a finished entry **lingers unacked up to one `claimTimeout`** before removal.
+Harmless: the **result is visible in the store immediately** (`getState`/`getResult` reflect
+completion the instant the worker writes terminal); only the stream entry lingers, and the
+terminal-state check prevents re-execution during the linger.
+
+Upgrade path if the linger ever matters: expose the claimed entry id + add a direct
+`ack(streamId, id)` primitive — the interface change Approach B is built on. Not done here.
+
+## 4. Design
+
+Collaborators inside `CommandServiceImpl` (plus one new factory). No stream changes.
+
+1. **Bounded worker pool** — `ThreadPoolExecutor(poolSize, poolSize, 0, MILLISECONDS,
+   new ArrayBlockingQueue<>(queueCapacity))` with a named daemon thread factory, owned as a
+   field. Runs the handler to completion. Replaces the injected
+   `@Named(TaskExecutors.BLOCKING) ExecutorService` and the `executeWithTimeout` logic. Lifecycle in §4.6.
+2. **In-flight set** — `Set<String> inFlight = ConcurrentHashMap.newKeySet()`. `inFlight.add(id)`
+   is the **atomic dedup gate**: the poll thread adds the id *before* submitting to the pool;
+   the worker removes it in a `finally`. Prevents the **same replica** from double-dispatching
+   a command whose own pending entry is reclaimed mid-run. (Registering before submit closes
+   the "worker finishes and removes before the poll thread records it" race.)
+3. **Single-runner lock** — `io.seqera.lock.LockManager` (`lib-lock`), injected
+   `@Named(COMMAND_LOCK)`. `tryAcquire(key)` is **non-blocking** (`null` if held elsewhere). The
+   Redis impl uses `SET NX PX` + a **watchdog** that renews the TTL every `ttl/3` while the
+   holder is alive; the key expires on crash. Cross-replica single-runner + crash recovery, no
+   hand-rolled heartbeat. In non-Redis mode `LocalLockManager` (in-JVM) is auto-selected.
+4. **checkStatus discrimination** — at `registerHandler`, compute once (via reflection) whether
+   the handler **overrides** `checkStatus`, cache in `Map<String,Boolean>`:
+   - override present ⇒ **external-job** handler (poll via `checkStatus`).
+   - not present ⇒ **in-process** handler (`execute` blocks to completion).
+   `CommandRegistration` (a published record) is **not** modified.
+5. **State store** — unchanged. The worker writes `RUNNING` then the terminal state.
+
+Task kinds dispatched to the pool: `EXECUTE` (call `handler.execute`) and `CHECK_STATUS`
+(call `handler.checkStatus`).
+
+### 4.1 `processCommand(msg)` — poll thread, fast, never runs a handler
+
+```
+state = store.findById(id).orElse(null)
+if state == null:                       return true    // stale, ack & drop
+if state.status().isTerminal():         return true    // ACK POINT (simplification #2)
+registration = getHandler(state.type())
+if registration == null:                store.save(state.failed("No handler…")); return true
+if !inFlight.add(id):                   return false   // already running here; wait for reclaim
+lock = lockManager.tryAcquire(lockKey(id))
+if lock == null:                        inFlight.remove(id); return false   // another replica owns it
+task = decideTask(state, registration)  // see §4.2
+try:
+    pool.execute(() -> runCommand(id, registration, lock, task))
+    return false                                         // leave unacked; ack later when terminal
+catch RejectedExecutionException:                        // pool saturated → backpressure
+    inFlight.remove(id); lock.release(); return false
+```
+
+`lockKey(id)` = `"cmd-queue/lock/" + id`. Ordering guarantee (must hold): the absent/terminal
+checks precede the `inFlight` check, so a stale in-flight entry can never block an ack.
+
+`decideTask(state, registration)`:
+- `state.status() == RUNNING && hasCustomCheckStatus(type)` → `CHECK_STATUS`
+- otherwise (`SUBMITTED`, or `RUNNING` for an in-process handler = crash re-run) → `EXECUTE`
+
+### 4.2 `runCommand(id, registration, lock, task)` — worker thread, to completion
+
+```
+try:
+    current = store.findById(id).orElse(null)
+    if current == null || current.status().isTerminal():   // cancelled/gone before we started
+        return
+    command = toCommand(current, registration)
+    if task == EXECUTE:
+        if current.status() != RUNNING:
+            store.save(current.started())                  // SUBMITTED → RUNNING
+        result = registration.handler().execute(command)
+    else: // CHECK_STATUS
+        result = registration.handler().checkStatus(command, current)
+
+    if result.status() == RUNNING:                         // external job still in progress
+        if current.status() != RUNNING:
+            store.save(current.started())
+        return                                             // leave unacked; redelivery re-polls
+    // terminal result → apply, but do not clobber a concurrent cancel (best-effort, see §5)
+    latest = store.findById(id).orElse(current)
+    if !latest.status().isTerminal():
+        store.save(latest.applyResult(result))
+catch Exception e:
+    latest = store.findById(id).orElse(current)
+    if latest != null && !latest.status().isTerminal():
+        store.save(latest.failed(e.getMessage()))
+finally:
+    inFlight.remove(id)
+    lock.release()                                         // watchdog stops; key deleted
+```
+
+`finally` order: terminal state is written **before** `inFlight.remove`/`lock.release`, so any
+reclaim racing completion either sees us in-flight (→ `false`) or sees terminal (→ ack).
+
+### 4.3 Correctness
+
+- **Single concurrent runner (cross-replica).** A replica runs a handler only while holding the
+  lock. A fresh message (`XREADGROUP`) goes to exactly one consumer; on reclaim another replica
+  must `tryAcquire` first and gets `null` while the holder is alive (watchdog renewing) → it does
+  not run. ⇒ at most one replica executes at a time.
+- **Crash recovery (at-least-once).** Holder dies → watchdog stops → lock TTL expires; the
+  message was never acked, so a later `XAUTOCLAIM` reclaims it and `tryAcquire` now succeeds.
+  In-process handler → `EXECUTE` re-runs the work; external-job handler → `CHECK_STATUS` polls the
+  external job that survived the crash. Recovery latency ≈ `max(claimTimeout, lockTTL)` after death.
+- **Same-replica redelivery.** `inFlight.add` short-circuits before the lock, so a replica never
+  double-runs its own command when its own pending entry is reclaimed mid-run.
+- **Backpressure.** Bounded pool queue; on `RejectedExecutionException` release the lock, remove
+  in-flight, leave the message queued for a later reclaim.
+- **Double-exec caveat (documented, inherent to distributed locks).** The window is bounded by
+  the lock TTL **only while the watchdog is healthy**. The watchdog survives transient renewal
+  errors (they are caught and retried at the next `ttl/3` tick) and only stops on a *confirmed*
+  ownership loss. But a sustained inability to renew — a JVM pause or a Redis partition longer than
+  the TTL, without the process dying — lets the key expire while the handler still runs, so a
+  second replica may start a concurrent run. This is standard lock-based "exactly-once-ish", not
+  true exactly-once. Set `commandLockDuration` comfortably larger than expected pauses. The
+  watchdog **must stay enabled** (`LockConfig.watchdogEnabled` default `true`) — disabling it
+  breaks the hold-while-alive guarantee.
+
+### 4.4 Configuration (additive, backward compatible)
+
+New **default** methods on `CommandConfig` (existing implementors keep compiling):
+
+```java
+default int commandPoolSize()          { return 10; }                  // worker threads
+default int commandPoolQueueSize()     { return 100; }                 // bounded queue → backpressure
+default Duration commandLockDuration() { return Duration.ofMinutes(1); } // lock TTL (watchdog renews ttl/3)
+```
+
+`executeTimeout()` is **kept** and marked `@Deprecated` (removing it from a published interface
+would break `TestCommandConfig` and any external implementor). Its Javadoc — and the "1 second"
+note in `CommandHandler.execute()` — are updated to state the value is no longer consulted and
+the handler now runs to completion on the worker pool. No `config.executeTimeout()` reference may
+remain in `CommandServiceImpl`.
+
+### 4.5 Wiring (`CommandLockFactory`, new file)
+
+Self-provisions one `@Named(COMMAND_LOCK) LockManager` so consumers need **no**
+`seqera.lock.*` config and the module works out of the box on upgrade:
+
+```java
+@Factory
+public class CommandLockFactory {
+    // reserved qualifier, unlikely to collide with a host seqera.lock.<name> key
+    static final String COMMAND_LOCK = "cmd-queue-internal-lock";
+
+    @Singleton @Named(COMMAND_LOCK) @Requires(bean = RedisActivator.class)
+    LockManager redis(JedisPool pool, TaskScheduler scheduler, CommandConfig config) {
+        var cfg = new LockConfig(COMMAND_LOCK);
+        cfg.setAutoExpireDuration(config.commandLockDuration());   // watchdogEnabled stays true (default)
+        return new RedisLockManager(cfg, pool, scheduler);
+    }
+    @Singleton @Named(COMMAND_LOCK) @Requires(missingBeans = RedisActivator.class)
+    LockManager local(CommandConfig config) {
+        var cfg = new LockConfig(COMMAND_LOCK);
+        cfg.setAutoExpireDuration(config.commandLockDuration());
+        return new LocalLockManager(cfg);
+    }
+}
+```
+
+`CommandServiceImpl` injects `@Inject @Named(CommandLockFactory.COMMAND_LOCK) LockManager lockManager`.
+
+**Bean-collision note:** `lib-lock`/`lib-lock-redis` register `@EachBean(LockConfig)` `LockManager`
+beans, one per configured `seqera.lock.<name>`, qualified by name. A host that configures
+`seqera.lock.cmd-queue-internal-lock` would collide with our qualifier — hence the deliberately
+reserved name. This is documented as reserved. A Micronaut context test (below) guards resolution.
+
+**Runtime precondition (redis mode):** the host must provide a `RedisActivator` bean and a
+`JedisPool` bean (e.g. via `lib-jedis-pool`). This already holds wherever this module runs against
+Redis, because `RedisMessageStream` and the state store it already depends on require the same
+`JedisPool`. Test fixtures (`lib-fixtures-redis`) provide both under the `redis` env.
+
+New `build.gradle` dependencies:
+```
+implementation project(':lib-lock')
+implementation project(':lib-lock-redis')
+implementation project(':lib-activator')        // RedisActivator on the compile classpath
+implementation 'redis.clients:jedis:5.1.4'       // JedisPool referenced by CommandLockFactory (compile classpath)
+```
+
+### 4.6 Lifecycle / shutdown
+
+Add an explicit `@PreDestroy` (so the container reclaims the pool even if `stop()` is not called),
+and make `stop()` delegate to it. Ordering:
+
+1. `started = false` (stop accepting; guards `start()` idempotency).
+2. `queue.close()` — stop the poll thread (no new dispatch).
+3. `pool.shutdown()` then `awaitTermination(bounded, e.g. 30s)` — let in-flight workers finish,
+   write terminal state, and release their own locks. If it times out, `pool.shutdownNow()`.
+
+Because in-flight workers release their locks in their own `finally`, a graceful drain leaves no
+lingering keys. A hard `shutdownNow()` interrupts handlers; the entries stay unacked and the locks
+expire by TTL → picked up elsewhere (at-least-once). Micronaut destroys beans in reverse creation
+order; `CommandServiceImpl`'s `@PreDestroy` runs before the `JedisPool`/lock beans it depends on.
+
+## 5. Behavioural / contract notes (all backward compatible)
+
+- **External-job pattern preserved.** `execute()` returning `CommandResult.running()` + a
+  `checkStatus()` override remains fully supported (see the "slow" integration test). The new
+  worker pool changes only *where* these run (off the poll thread), not the semantics.
+- **`checkStatus()` now runs on the worker pool** instead of synchronously on the poll thread
+  (non-blocking) — an improvement, not a break.
+- **Very fast commands** now transition `SUBMITTED → RUNNING → SUCCEEDED` (they briefly pass
+  through `RUNNING`), where before a sub-timeout command could skip `RUNNING`. Matches the
+  documented state machine; add a one-line changelog note as downstream pollers may now observe
+  `RUNNING`.
+- **`cancel()` is best-effort / advisory.** It writes `CANCELLED` but does **not** interrupt a
+  running handler (matching current behaviour). The worker's terminal write is guarded by a
+  re-read (won't overwrite a `CANCELLED` observed before the write), but a `cancel()` landing in
+  the narrow gap between the re-read and the write can still be overwritten by a completing worker.
+  This residual race exists in the current code too and is accepted; documented here.
+- **Per-command cost increases**: each command now does `tryAcquire` (one `SET NX`) + a `RUNNING`
+  write + a terminal write + a deferred ack, versus the old inline fast path. This is the price of
+  non-blocking parallelism + single-runner and is accepted. Skipping the lock for
+  complete-on-first-delivery commands is a possible future optimization (reopens a double-exec
+  window; deferred).
+- **Local (non-Redis) mode is effectively serial for intake.** `LocalMessageStream.consume()`
+  sleeps 1s on the poll thread and re-offers on `false`, so each in-flight command costs a 1s
+  poll-thread stall and there is no real reclaim/idle concept. The non-blocking benefit and the
+  single-runner guarantee are Redis-mode properties; concurrency assertions must use Testcontainers.
+
+## 6. Test plan
+
+**Unit (Spock, mocked `store`/`lockManager`/pool):**
+1. Terminal state on delivery → returns `true`, no dispatch.
+2. Absent state → returns `true`.
+3. No handler → saves `FAILED`, returns `true`.
+4. Fresh `SUBMITTED`, lock acquired → adds in-flight, submits `EXECUTE`, returns `false`.
+5. Lock held elsewhere (`tryAcquire` → null) → returns `false`, in-flight NOT left populated, no dispatch.
+6. Already in-flight (`add` returns false) → returns `false`, no `tryAcquire`, no dispatch.
+7. Pool saturated (`execute` throws `RejectedExecutionException`) → lock released, in-flight removed, returns `false`.
+8. `RUNNING` state + handler with `checkStatus` override → dispatches `CHECK_STATUS`.
+9. `RUNNING` state + in-process handler (no override) → dispatches `EXECUTE` (crash re-run).
+10. `runCommand` EXECUTE happy path → `RUNNING` then `SUCCEEDED`; in-flight cleared; lock released.
+11. `runCommand` EXECUTE returns `running()` → stays `RUNNING`, no terminal write, lock released, in-flight cleared.
+12. `runCommand` handler throws → `FAILED`; lock released; in-flight cleared.
+13. `runCommand` sees `CANCELLED` landed before the terminal re-read → does not overwrite it.
+14. Fast worker completes before `processCommand` finishes → assert in-flight ends empty (no leak) and a subsequent terminal delivery acks.
+15. **Bean resolution:** a Micronaut `ApplicationContext` (no `seqera.lock.*`) resolves exactly one `@Named(COMMAND_LOCK) LockManager`.
+16. `@PreDestroy`/`stop()` terminates the pool (assert `pool.isTerminated()`), draining an in-flight worker first.
+
+**Existing local tests (regression — must stay green):** the full `CommandServiceTest` including the
+"slow"/`checkStatus` scenario and `cancel`.
+
+**Integration (Testcontainers Redis, via `lib-fixtures-redis`; mirror an existing Redis-backed Spock
+test in a sibling module for setup):**
+17. Long in-process handler does **not** block intake: submit a long command then a short one; the
+    short one completes while the long one is still running.
+18. **Single-runner across two replicas:** two manually-wired `CommandServiceImpl` instances sharing
+    one `JedisPool` + one `RedisStreamConfig` (same stream name, same consumer group, distinct
+    consumer names) + one shared Redis lock keyspace, with a **small** `claimTimeout` and a handler
+    that increments an `AtomicInteger` and sleeps past the claim timeout. Wrap each replica's
+    `LockManager` in a counting delegate; assert `execute()` ran **exactly once** AND the second
+    replica's `tryAcquire` was invoked and returned `null` (proves lock-mediated exclusion, not mere
+    non-delivery).
+19. **Crash recovery:** run a long in-process command on instance A; simulate death by abandoning A
+    **without** releasing its lock (e.g. do not call `stop()`; stop A's watchdog scheduler / drop the
+    instance) so the key expires by TTL; assert instance B reaches a terminal state, only after ~lockTTL.
+20. **Ack-on-reclaim (simplification #2):** after a command reaches terminal, assert stream length
+    returns to 0 within ~`claimTimeout`.
+
+If Docker is unavailable, tests 17–20 are skipped (documented) while unit + local tests still validate
+the logic and no regression.
+
+## 7. Files touched
+
+- `CommandServiceImpl.java` — replace inline `executeWithTimeout` with non-blocking dispatch +
+  `runCommand`; add pool, `inFlight` set, lock, checkStatus-override cache, `decideTask`; `@PreDestroy` + `stop()` drain.
+- `CommandConfig.java` — add 3 default config methods; deprecate `executeTimeout()` with updated Javadoc.
+- `CommandHandler.java` — update Javadoc (the "1 second" note).
+- `CommandLockFactory.java` — **new**.
+- `build.gradle` — add `lib-lock`, `lib-lock-redis`, `lib-activator`, `redis.clients:jedis:5.1.4`.
+- Tests — new unit specs (§6.1–16) + new Redis integration spec (§6.17–20); keep existing local specs green.
+- `README.md` / `changelog.txt` / `VERSION` — updated on release (separate step, not part of impl).

--- a/lib-cmd-queue-redis/build.gradle
+++ b/lib-cmd-queue-redis/build.gradle
@@ -39,6 +39,12 @@ dependencies {
     // State store
     implementation project(':lib-data-store-state-redis')
 
+    // Distributed lock (single-runner guarantee for async command execution)
+    implementation project(':lib-lock')
+    implementation project(':lib-lock-redis')
+    implementation project(':lib-activator')
+    implementation 'redis.clients:jedis:5.1.4'
+
     // Utilities (includes type resolution)
     implementation project(':lib-lang')
 

--- a/lib-cmd-queue-redis/src/main/java/io/seqera/data/command/CommandConfig.java
+++ b/lib-cmd-queue-redis/src/main/java/io/seqera/data/command/CommandConfig.java
@@ -37,12 +37,39 @@ public interface CommandConfig {
     }
 
     /**
-     * Timeout for synchronous command execution.
-     * If execute() takes longer than this, the command is marked as RUNNING
-     * and checkStatus() will be called on subsequent queue deliveries.
+     * @deprecated No longer consulted. Command handlers now run to completion on a bounded worker
+     * pool (see {@link CommandHandler#execute}); there is no synchronous execution timeout. Retained
+     * only for source/binary backward compatibility. Will be removed in a future major release.
      */
+    @Deprecated
     default Duration executeTimeout() {
         return Duration.ofSeconds(1);
+    }
+
+    /**
+     * Number of worker threads used to execute command handlers concurrently, off the queue poll
+     * thread. Also caps the number of commands executing at once per replica.
+     */
+    default int commandPoolSize() {
+        return 10;
+    }
+
+    /**
+     * Bounded capacity of the worker pool queue. When full, newly delivered commands are left in the
+     * message queue (not acknowledged) and retried on a later delivery, providing backpressure.
+     */
+    default int commandPoolQueueSize() {
+        return 100;
+    }
+
+    /**
+     * Time-to-live of the per-command single-runner lock. While the holding replica is alive the
+     * lock is auto-renewed (watchdog) so it is effectively held for the whole execution; if the
+     * replica dies, the lock expires after this duration and another replica can take over. Set it
+     * comfortably larger than any expected JVM pause or Redis partition.
+     */
+    default Duration commandLockDuration() {
+        return Duration.ofMinutes(1);
     }
 
     /**

--- a/lib-cmd-queue-redis/src/main/java/io/seqera/data/command/CommandHandler.java
+++ b/lib-cmd-queue-redis/src/main/java/io/seqera/data/command/CommandHandler.java
@@ -33,11 +33,16 @@ public interface CommandHandler<P, R> {
 
     /**
      * Execute the command and return a result.
-     * This method is executed asynchronously via an executor service.
-     * If execution takes longer than 1 second, the command is marked as RUNNING and
-     * {@link #checkStatus} will be called periodically to check completion.
-     * For long-running commands, return {@link CommandResult#running()} to indicate
-     * the operation is in progress.
+     *
+     * <p>This method runs on a bounded worker pool, off the queue poll thread, and may block for as
+     * long as needed — the command is marked {@code RUNNING} for its whole duration and no timeout is
+     * applied. There are two supported patterns:
+     * <ul>
+     *   <li><b>In-process:</b> do the work and return a terminal {@link CommandResult}
+     *       ({@code success}/{@code failure}). No {@link #checkStatus} override is needed.</li>
+     *   <li><b>External job:</b> kick off external work, return {@link CommandResult#running()}, and
+     *       override {@link #checkStatus} to poll for completion on subsequent deliveries.</li>
+     * </ul>
      *
      * @param command The command to execute
      * @return The result of the execution

--- a/lib-cmd-queue-redis/src/main/java/io/seqera/data/command/CommandLockFactory.java
+++ b/lib-cmd-queue-redis/src/main/java/io/seqera/data/command/CommandLockFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.seqera.data.command;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.scheduling.TaskScheduler;
+import io.seqera.activator.redis.RedisActivator;
+import io.seqera.lock.LockConfig;
+import io.seqera.lock.LockManager;
+import io.seqera.lock.local.LocalLockManager;
+import io.seqera.lock.redis.RedisLockManager;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import redis.clients.jedis.JedisPool;
+
+/**
+ * Self-provisions the {@link LockManager} used by {@link CommandServiceImpl} to guarantee that a
+ * given command's handler is not executed concurrently on more than one replica.
+ *
+ * <p>The manager is provided under the reserved qualifier {@link #COMMAND_LOCK} so consumers do not
+ * need to configure {@code seqera.lock.*} for the command queue to work, and so it does not clash
+ * with any {@link LockManager} beans the host application defines via {@code seqera.lock.<name>}.
+ * Because the qualifier doubles as a {@link LockConfig} name, {@link #COMMAND_LOCK} is deliberately
+ * an unlikely configuration key and is reserved for this use.
+ *
+ * <p><b>Redis-mode runtime precondition:</b> the host must provide a {@link RedisActivator} bean and
+ * a {@link JedisPool} bean (e.g. via {@code lib-jedis-pool}). This already holds wherever this module
+ * runs against Redis, since the message stream and state store it depends on require the same pool.
+ * When Redis is not active a purely in-JVM {@link LocalLockManager} is used instead.
+ *
+ * @author Paolo Di Tommaso
+ */
+@Factory
+public class CommandLockFactory {
+
+    /**
+     * Reserved qualifier / {@link LockConfig} name for the command-queue single-runner lock.
+     */
+    public static final String COMMAND_LOCK = "cmd-queue-internal-lock";
+
+    @Singleton
+    @Named(COMMAND_LOCK)
+    @Requires(bean = RedisActivator.class)
+    LockManager redisCommandLock(JedisPool pool, TaskScheduler scheduler, CommandConfig config) {
+        final var cfg = new LockConfig(COMMAND_LOCK);
+        // watchdog stays enabled (LockConfig default) so the lock is held while the holder is alive
+        // and expires by TTL on crash — do not disable it
+        cfg.setAutoExpireDuration(config.commandLockDuration());
+        return new RedisLockManager(cfg, pool, scheduler);
+    }
+
+    @Singleton
+    @Named(COMMAND_LOCK)
+    @Requires(missingBeans = RedisActivator.class)
+    LockManager localCommandLock(CommandConfig config) {
+        final var cfg = new LockConfig(COMMAND_LOCK);
+        cfg.setAutoExpireDuration(config.commandLockDuration());
+        return new LocalLockManager(cfg);
+    }
+}

--- a/lib-cmd-queue-redis/src/main/java/io/seqera/data/command/CommandServiceImpl.java
+++ b/lib-cmd-queue-redis/src/main/java/io/seqera/data/command/CommandServiceImpl.java
@@ -16,16 +16,23 @@
  */
 package io.seqera.data.command;
 
+import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import io.micronaut.scheduling.TaskExecutors;
 import io.seqera.data.command.store.CommandStateStore;
+import io.seqera.lock.Lock;
+import io.seqera.lock.LockManager;
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
@@ -34,20 +41,30 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of the command service.
- * Handles queue consumption and command execution with proper multi-replica support.
  *
- * <p>Processing flow:
+ * <p>Commands are consumed from the queue on a single poll thread which never runs a handler
+ * itself. Instead it dispatches each command to a bounded worker pool and returns immediately, so
+ * multiple commands execute concurrently and the poll thread never blocks. A per-command
+ * distributed lock ({@link LockManager}) guarantees a command's handler is not executed
+ * concurrently on more than one replica; the lock auto-renews while the holder is alive and expires
+ * on crash, giving at-least-once recovery.
+ *
+ * <p>Processing flow for a delivered message (all on the poll thread, fast, non-blocking):
  * <ul>
- *   <li>If command is already RUNNING → call checkStatus() synchronously</li>
- *   <li>If command is not RUNNING → execute asynchronously with 1-second timeout:
- *       <ul>
- *         <li>If completes within timeout → process result immediately</li>
- *         <li>If times out → mark as RUNNING, retry later via queue</li>
- *       </ul>
- *   </li>
- *   <li>If result is RUNNING → return false (message stays in queue for retry)</li>
- *   <li>If result is terminal → return true (message removed from queue)</li>
+ *   <li>state missing or already terminal → acknowledge (remove from queue)</li>
+ *   <li>no handler registered → mark FAILED, acknowledge</li>
+ *   <li>already running on this replica → leave in queue (redelivered later)</li>
+ *   <li>lock held by another replica → leave in queue</li>
+ *   <li>otherwise → dispatch to the worker pool, leave in queue; it is acknowledged on a later
+ *       delivery once the store shows a terminal state</li>
  * </ul>
+ *
+ * <p>On the worker pool, a {@code SUBMITTED} command (or a {@code RUNNING} command whose handler has
+ * no {@code checkStatus} override — i.e. crash recovery of in-process work) runs
+ * {@link CommandHandler#execute}; a {@code RUNNING} command whose handler overrides
+ * {@code checkStatus} (external-job pattern) runs {@link CommandHandler#checkStatus}. A
+ * {@link CommandResult#running()} result leaves the command {@code RUNNING} to be re-polled on a
+ * later delivery; a terminal result transitions the command to its terminal state.
  */
 @Singleton
 public class CommandServiceImpl implements CommandService {
@@ -64,10 +81,19 @@ public class CommandServiceImpl implements CommandService {
     private CommandQueue queue;
 
     @Inject
-    @Named(TaskExecutors.BLOCKING)
-    private ExecutorService executor;
+    @Named(CommandLockFactory.COMMAND_LOCK)
+    private LockManager lockManager;
 
     private final Map<String, CommandRegistration<?, ?>> handlers = new ConcurrentHashMap<>();
+
+    /** Whether a handler type overrides {@link CommandHandler#checkStatus} (external-job pattern). */
+    private final Map<String, Boolean> checkStatusOverride = new ConcurrentHashMap<>();
+
+    /** Commands currently executing on this replica — atomic dedup gate against self-redelivery. */
+    private final Set<String> inFlight = ConcurrentHashMap.newKeySet();
+
+    /** Bounded pool that runs handlers off the poll thread. Created in {@link #start()}. */
+    private volatile ExecutorService pool;
 
     private volatile boolean started = false;
 
@@ -78,8 +104,14 @@ public class CommandServiceImpl implements CommandService {
             return;
         }
         started = true;
+        this.pool = new ThreadPoolExecutor(
+                config.commandPoolSize(), config.commandPoolSize(),
+                0L, TimeUnit.MILLISECONDS,
+                new ArrayBlockingQueue<>(config.commandPoolQueueSize()),
+                workerThreadFactory());
         queue.addConsumer(this::processCommand);
-        log.info("Command service started - consuming commands");
+        log.info("Command service started - consuming commands (poolSize={}, queueCapacity={})",
+                config.commandPoolSize(), config.commandPoolQueueSize());
     }
 
     @Override
@@ -88,8 +120,37 @@ public class CommandServiceImpl implements CommandService {
             return;
         }
         started = false;
+        // stop accepting new work first, then drain in-flight workers so they finish, write their
+        // terminal state and release their own locks before pool/lock beans are torn down
         queue.close();
+        final var p = pool;
+        if (p != null) {
+            p.shutdown();
+            try {
+                if (!p.awaitTermination(30, TimeUnit.SECONDS)) {
+                    log.warn("Command worker pool did not drain within 30s - forcing shutdown");
+                    p.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                p.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
         log.info("Command service stopped");
+    }
+
+    @PreDestroy
+    void destroy() {
+        stop();
+    }
+
+    private static ThreadFactory workerThreadFactory() {
+        final AtomicInteger counter = new AtomicInteger();
+        return runnable -> {
+            final Thread t = new Thread(runnable, "cmd-queue-worker-" + counter.incrementAndGet());
+            t.setDaemon(true);
+            return t;
+        };
     }
 
     @Override
@@ -129,6 +190,11 @@ public class CommandServiceImpl implements CommandService {
             return false;
         }
 
+        // Best-effort / advisory: this flips the persisted state to CANCELLED but does NOT interrupt
+        // a handler already running on the worker pool. A worker completing in the narrow window
+        // after this write may still overwrite it (see runCommand's terminal-write guard). The
+        // queued stream entry (if any) is not acked here; it is reclaimed and dropped lazily on a
+        // later delivery once the terminal state is observed (same linger as normal completion).
         store.save(state.cancelled());
         log.info("Command cancelled: id={}", commandId);
         return true;
@@ -138,6 +204,7 @@ public class CommandServiceImpl implements CommandService {
     public <P, R> void registerHandler(CommandHandler<P, R> handler) {
         final var registration = CommandRegistration.of(handler);
         handlers.put(handler.type(), registration);
+        checkStatusOverride.put(handler.type(), overridesCheckStatus(handler));
         log.debug("Registered command handler: type={}", handler.type());
     }
 
@@ -171,37 +238,54 @@ public class CommandServiceImpl implements CommandService {
     }
 
     /**
-     * Process a command message received from the queue.
-     *
-     * <p>This is the entry point for queue message consumption. It performs initial
-     * validation and state lookup, then delegates to the type-safe handler method.
+     * Whether the handler provides its own {@link CommandHandler#checkStatus} implementation (as
+     * opposed to inheriting the interface default). Handlers that override it follow the external-job
+     * pattern (execute() returns {@code running()} and progress is polled via checkStatus()).
+     */
+    static boolean overridesCheckStatus(CommandHandler<?, ?> handler) {
+        try {
+            final Method m = handler.getClass().getMethod("checkStatus", Command.class, CommandState.class);
+            return m.getDeclaringClass() != CommandHandler.class;
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
+    }
+
+    private static String lockKey(String commandId) {
+        return "cmd-queue/lock/" + commandId;
+    }
+
+    /**
+     * Process a command message received from the queue. Runs on the poll thread and must be fast:
+     * it never executes a handler, only dispatches to the worker pool.
      *
      * <p>Return value semantics (controls queue behavior):
      * <ul>
-     *   <li>{@code true} = command fully processed, remove message from queue</li>
-     *   <li>{@code false} = command needs retry, keep message in queue for redelivery</li>
+     *   <li>{@code true} = remove the message from the queue (acknowledge)</li>
+     *   <li>{@code false} = keep the message for later redelivery</li>
      * </ul>
      *
-     * @param msg The command message containing commandId and type
-     * @return true to acknowledge (remove from queue), false to retry later
+     * @param msg the command message containing commandId and type
+     * @return true to acknowledge, false to retry later
      */
-    private boolean processCommand(CommandMsg msg) {
-        // Step 1: Load command state from persistent storage
-        var state = store.findById(msg.commandId()).orElse(null);
+    boolean processCommand(CommandMsg msg) {
+        final String id = msg.commandId();
+
+        // Load command state from persistent storage
+        final var state = store.findById(id).orElse(null);
         if (state == null) {
-            log.error("Command state not found - this should not happen: id={}", msg.commandId());
+            log.error("Command state not found - this should not happen: id={}", id);
             return true;
         }
 
-        // Step 2: Check if command already reached a terminal state (SUCCEEDED/FAILED/CANCELLED)
-        // This can happen if another replica processed it, or if it was cancelled.
-        // Return true to remove the now-stale message from the queue.
+        // Already terminal (another replica finished it, or it was cancelled): acknowledge & drop.
+        // NOTE: this check MUST precede the in-flight check so a completed command is always acked
+        // even if a stale in-flight entry lingered.
         if (state.status().isTerminal()) {
             return true;
         }
 
-        // Step 3: Look up the registered handler for this command type
-        // If no handler is registered, mark as FAILED and remove from queue.
+        // No handler registered for this type: mark FAILED and drop
         final var registration = getHandler(state.type());
         if (registration == null) {
             log.error("No handler for command type: {}", state.type());
@@ -209,128 +293,88 @@ public class CommandServiceImpl implements CommandService {
             return true;
         }
 
-        // Step 4: Delegate to the type-capturing helper method
-        // This pattern allows Java to infer concrete type parameters (P, R) from the
-        // CommandRegistration, enabling type-safe handler invocation without raw types.
-        return processCommandWithHandler(msg, state, registration);
-    }
+        // Atomic dedup gate: if we are already running this command on this replica, leave the
+        // message in the queue (it will be redelivered) and do nothing. Registering BEFORE the pool
+        // submit prevents a fast worker from removing the entry before we record it.
+        if (!inFlight.add(id)) {
+            return false;
+        }
 
-    /**
-     * Execute command processing with a specific handler registration.
-     *
-     * <p>This helper method captures the type parameters {@code <P, R>} from the
-     * {@link CommandRegistration}, allowing type-safe interaction with the handler.
-     *
-     * <p>Processing flow:
-     * <ol>
-     *   <li>If command is already RUNNING → call {@code checkStatus()} to poll for completion</li>
-     *   <li>If command is not yet RUNNING → call {@code execute()} with timeout:
-     *       <ul>
-     *         <li>If completes within timeout → process the result immediately</li>
-     *         <li>If times out → mark as RUNNING, return false to retry later</li>
-     *       </ul>
-     *   </li>
-     *   <li>If result status is RUNNING → return false (keep in queue for polling)</li>
-     *   <li>If result status is terminal → update state and return true (done)</li>
-     * </ol>
-     *
-     * @param msg The original queue message (for logging)
-     * @param state The current command state from storage (wildcard types)
-     * @param registration The handler registration with type parameters captured
-     * @param <P> The command parameter type
-     * @param <R> The command result type
-     * @return true to acknowledge (remove from queue), false to retry later
-     */
-    private <P, R> boolean processCommandWithHandler(
-            CommandMsg msg,
-            CommandState state,
-            CommandRegistration<P, R> registration) {
+        // Single-runner across replicas: only the lock holder runs the handler
+        final Lock lock = lockManager.tryAcquire(lockKey(id));
+        if (lock == null) {
+            inFlight.remove(id);
+            return false;
+        }
 
-        // Reconstruct the typed Command object from persisted state
-        // Uses Class.cast() internally for type-safe conversion
-        final Command<P> command = toCommand(state, registration);
-        final CommandHandler<P, R> handler = registration.handler();
+        // RUNNING + a handler that overrides checkStatus => external-job polling; otherwise execute()
+        // (SUBMITTED, or crash recovery of in-process work that was left RUNNING)
+        final boolean doCheckStatus = state.status() == CommandStatus.RUNNING
+                && checkStatusOverride.getOrDefault(state.type(), Boolean.FALSE);
 
         try {
-            CommandResult<R> result;
-
-            // Branch based on current command status
-            if (state.status() == CommandStatus.RUNNING) {
-                // Command was previously marked as RUNNING (long-running async operation)
-                // Call checkStatus() to poll the external system for completion
-                result = handler.checkStatus(command, state);
-            } else {
-                // Command not yet running (status is SUBMITTED)
-                // Execute with timeout to avoid blocking the queue processor indefinitely
-                result = executeWithTimeout(handler, command);
-
-                // Timeout case: execute() is still running in background thread
-                // Mark state as RUNNING so next delivery will call checkStatus() instead
-                if (result == null) {
-                    store.save(state.started());
-                    return false; // Keep in queue - will retry and call checkStatus()
-                }
-            }
-
-            // Handler returned a result - check if command is still in progress
-            if (result.status() == CommandStatus.RUNNING) {
-                // Handler explicitly returned RUNNING (e.g., async job not yet complete)
-                // Ensure state reflects RUNNING status for accurate reporting
-                if (state.status() != CommandStatus.RUNNING) {
-                    store.save(state.started());
-                }
-                return false; // Keep in queue - will retry and call checkStatus()
-            }
-
-            // Terminal result (SUCCEEDED, FAILED, or CANCELLED)
-            // Apply the result to transition to terminal state
-            final CommandState newState = state.applyResult(result);
-            store.save(newState);
-            log.debug("Command completed: id={}, status={}", state.id(), newState.status());
-            return true; // Remove from queue - processing complete
-
-        } catch (Exception e) {
-            // Unexpected exception during processing - mark as FAILED
-            log.error("Command processing failed: id={}", msg.commandId(), e);
-            store.save(state.failed(e.getMessage()));
-            return true; // Remove from queue - no point retrying a crashed handler
+            pool.execute(() -> runCommand(id, registration, lock, doCheckStatus));
+            return false; // leave unacked; acknowledged on a later delivery once terminal
+        } catch (RejectedExecutionException e) {
+            // pool saturated → backpressure: undo and leave the message queued for later
+            inFlight.remove(id);
+            lock.release();
+            log.debug("Command worker pool saturated, will retry later: id={}", id);
+            return false;
         }
     }
 
     /**
-     * Execute a command handler with a timeout.
+     * Execute (or check the status of) a command on a worker thread, to completion.
      *
-     * <p>Submits the handler's {@code execute()} method to a thread pool and waits
-     * up to {@code config.executeTimeout()} for completion. This prevents slow handlers from
-     * blocking the queue processor thread.
-     *
-     * <p>Timeout behavior: If the handler doesn't complete within the timeout,
-     * this method returns {@code null} but the handler continues executing in the
-     * background. The caller should mark the command as RUNNING and retry later
-     * via {@code checkStatus()}.
-     *
-     * @param handler The command handler to execute
-     * @param command The command with parameters
-     * @param <P> The command parameter type
-     * @param <R> The command result type
-     * @return The result if completed within timeout, or {@code null} if timed out
-     * @throws RuntimeException if the handler throws an exception
+     * @param id            the command id
+     * @param registration  the resolved handler registration
+     * @param lock          the single-runner lock held for this command; released here
+     * @param doCheckStatus true to poll via {@link CommandHandler#checkStatus}, false to run
+     *                      {@link CommandHandler#execute}
      */
-    private <P, R> CommandResult<R> executeWithTimeout(CommandHandler<P, R> handler, Command<P> command) {
-        // Submit handler execution to thread pool for async execution
-        final Future<CommandResult<R>> future = executor.submit(() -> handler.execute(command));
-
+    <P, R> void runCommand(String id, CommandRegistration<P, R> registration, Lock lock, boolean doCheckStatus) {
         try {
-            // Block until result is available or timeout expires
-            return future.get(config.executeTimeout().toMillis(), TimeUnit.MILLISECONDS);
-        } catch (TimeoutException e) {
-            // Handler is taking longer than allowed - let it continue in background
-            // Caller will mark as RUNNING and poll via checkStatus() on retry
-            return null;
+            final var current = store.findById(id).orElse(null);
+            if (current == null || current.status().isTerminal()) {
+                return; // cancelled or gone before we started
+            }
+
+            final Command<P> command = toCommand(current, registration);
+            final CommandHandler<P, R> handler = registration.handler();
+            final CommandResult<R> result;
+
+            if (doCheckStatus) {
+                result = handler.checkStatus(command, current);
+            } else {
+                if (current.status() != CommandStatus.RUNNING) {
+                    store.save(current.started()); // SUBMITTED → RUNNING
+                }
+                result = handler.execute(command);
+            }
+
+            if (result.status() == CommandStatus.RUNNING) {
+                // still in progress (external job) - leave RUNNING, re-polled on a later delivery
+                return;
+            }
+
+            // Terminal result: apply it, but do not clobber a concurrent cancel (best-effort).
+            final var latest = store.findById(id).orElse(current);
+            if (!latest.status().isTerminal()) {
+                store.save(latest.applyResult(result));
+                log.debug("Command completed: id={}, status={}", id, result.status());
+            }
         } catch (Exception e) {
-            // Handler threw an exception - cancel the future and propagate
-            future.cancel(true);
-            throw new RuntimeException("Command execution failed", e);
+            log.error("Command processing failed: id={}", id, e);
+            final var latest = store.findById(id).orElse(null);
+            if (latest != null && !latest.status().isTerminal()) {
+                store.save(latest.failed(e.getMessage()));
+            }
+        } finally {
+            // Order matters: the terminal state was written above, before we drop these, so a reclaim
+            // racing completion either sees us in-flight (returns false) or sees terminal (acks).
+            inFlight.remove(id);
+            lock.release();
         }
     }
 }

--- a/lib-cmd-queue-redis/src/test/groovy/io/seqera/data/command/CmdRedisStreamConfig.groovy
+++ b/lib-cmd-queue-redis/src/test/groovy/io/seqera/data/command/CmdRedisStreamConfig.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.seqera.data.command
+
+import java.time.Duration
+
+import io.micronaut.context.annotation.Requires
+import io.seqera.data.stream.impl.RedisStreamConfig
+import jakarta.inject.Singleton
+
+/**
+ * Redis stream configuration for the Redis-backed integration tests. A short claim timeout makes
+ * the "another replica reclaims an in-flight command" path exercisable within the test window.
+ */
+@Requires(env = 'redis')
+@Singleton
+class CmdRedisStreamConfig implements RedisStreamConfig {
+
+    @Override
+    String getDefaultConsumerGroupName() {
+        return 'cmd-queue-test-group'
+    }
+
+    @Override
+    Duration getClaimTimeout() {
+        return Duration.ofSeconds(1)
+    }
+
+    @Override
+    Duration getConsumerWarnTimeout() {
+        return Duration.ofSeconds(5)
+    }
+}

--- a/lib-cmd-queue-redis/src/test/groovy/io/seqera/data/command/CommandLockWiringTest.groovy
+++ b/lib-cmd-queue-redis/src/test/groovy/io/seqera/data/command/CommandLockWiringTest.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.seqera.data.command
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.seqera.lock.LockManager
+import io.seqera.lock.local.LocalLockManager
+import spock.lang.Specification
+
+/**
+ * Guards the command-lock DI wiring: exactly one {@code @Named(COMMAND_LOCK)} {@link LockManager}
+ * must resolve (no ambiguity with the {@code @EachBean(LockConfig)} managers), and the command
+ * service must inject it. Docker-independent (local, non-Redis) so wiring is proven even without
+ * the integration tests.
+ */
+class CommandLockWiringTest extends Specification {
+
+    def 'resolves exactly one command lock manager (local mode) and injects the service'() {
+        given:
+        def ctx = ApplicationContext.run('test')
+
+        when:
+        def beans = ctx.getBeansOfType(LockManager, Qualifiers.byName(CommandLockFactory.COMMAND_LOCK))
+
+        then:
+        beans.size() == 1
+        beans.first() instanceof LocalLockManager
+
+        and: 'the command service resolves (its @Named lock injection is unambiguous)'
+        ctx.getBean(CommandService) != null
+
+        cleanup:
+        ctx?.close()
+    }
+}

--- a/lib-cmd-queue-redis/src/test/groovy/io/seqera/data/command/CommandServiceProcessingTest.groovy
+++ b/lib-cmd-queue-redis/src/test/groovy/io/seqera/data/command/CommandServiceProcessingTest.groovy
@@ -1,0 +1,311 @@
+/*
+ * Copyright 2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.seqera.data.command
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.RejectedExecutionException
+
+import io.seqera.data.command.store.CommandStateStore
+import io.seqera.lock.Lock
+import io.seqera.lock.LockManager
+import spock.lang.Specification
+
+/**
+ * Unit tests for the async dispatch and worker logic of {@link CommandServiceImpl},
+ * driving processCommand/runCommand directly with mocked collaborators.
+ */
+class CommandServiceProcessingTest extends Specification {
+
+    CommandServiceImpl svc
+    CommandStateStore store
+    LockManager lockManager
+    ExecutorService pool
+
+    def setup() {
+        svc = new CommandServiceImpl()
+        store = Mock(CommandStateStore)
+        lockManager = Mock(LockManager)
+        pool = Mock(ExecutorService)
+        svc.@store = store
+        svc.@lockManager = lockManager
+        svc.@pool = pool
+        svc.@config = new CommandConfig() {}
+    }
+
+    private static CommandState submitted(String id) {
+        CommandState.submitted(id, 'test', new TestParams(1, 'fast'))
+    }
+
+    private static CommandState running(String id) {
+        submitted(id).started()
+    }
+
+    // ---- processCommand gating (poll thread) ----
+
+    def 'acknowledges when state is absent'() {
+        when:
+        def ack = svc.processCommand(CommandMsg.of('c1', 'test'))
+        then:
+        1 * store.findById('c1') >> Optional.empty()
+        0 * pool.execute(_)
+        ack
+    }
+
+    def 'acknowledges when state is already terminal'() {
+        when:
+        def ack = svc.processCommand(CommandMsg.of('c1', 'test'))
+        then:
+        1 * store.findById('c1') >> Optional.of(submitted('c1').completed(new TestResult('x', 1)))
+        0 * pool.execute(_)
+        ack
+    }
+
+    def 'marks FAILED and acknowledges when no handler registered'() {
+        when:
+        def ack = svc.processCommand(CommandMsg.of('c1', 'test'))
+        then:
+        1 * store.findById('c1') >> Optional.of(submitted('c1'))
+        1 * store.save({ it.status() == CommandStatus.FAILED })
+        0 * pool.execute(_)
+        ack
+    }
+
+    def 'dispatches EXECUTE and stays queued for a fresh SUBMITTED command with lock acquired'() {
+        given:
+        svc.registerHandler(new InProcHandler())
+        def lock = Mock(Lock)
+        when:
+        def ack = svc.processCommand(CommandMsg.of('c1', 'test'))
+        then:
+        1 * store.findById('c1') >> Optional.of(submitted('c1'))
+        1 * lockManager.tryAcquire('cmd-queue/lock/c1') >> lock
+        1 * pool.execute(_)
+        !ack
+        svc.@inFlight.contains('c1')
+    }
+
+    def 'stays queued and does not dispatch when the lock is held by another replica'() {
+        given:
+        svc.registerHandler(new InProcHandler())
+        when:
+        def ack = svc.processCommand(CommandMsg.of('c1', 'test'))
+        then:
+        1 * store.findById('c1') >> Optional.of(submitted('c1'))
+        1 * lockManager.tryAcquire(_) >> null
+        0 * pool.execute(_)
+        !ack
+        !svc.@inFlight.contains('c1')
+    }
+
+    def 'does not re-dispatch or re-lock when already in-flight on this replica'() {
+        given:
+        svc.registerHandler(new InProcHandler())
+        svc.@inFlight.add('c1')
+        when:
+        def ack = svc.processCommand(CommandMsg.of('c1', 'test'))
+        then:
+        1 * store.findById('c1') >> Optional.of(submitted('c1'))
+        0 * lockManager.tryAcquire(_)
+        0 * pool.execute(_)
+        !ack
+    }
+
+    def 'releases the lock and stays queued when the pool is saturated (backpressure)'() {
+        given:
+        svc.registerHandler(new InProcHandler())
+        def lock = Mock(Lock)
+        when:
+        def ack = svc.processCommand(CommandMsg.of('c1', 'test'))
+        then:
+        1 * store.findById('c1') >> Optional.of(submitted('c1'))
+        1 * lockManager.tryAcquire(_) >> lock
+        1 * pool.execute(_) >> { throw new RejectedExecutionException('full') }
+        1 * lock.release()
+        !ack
+        !svc.@inFlight.contains('c1')
+    }
+
+    // ---- runCommand (worker thread) ----
+
+    def 'runCommand: EXECUTE marks RUNNING then SUCCEEDED, clears in-flight and releases lock'() {
+        given:
+        def reg = CommandRegistration.of(new InProcHandler())
+        def lock = Mock(Lock)
+        svc.@inFlight.add('c1')
+        def st = submitted('c1')
+        when:
+        svc.runCommand('c1', reg, lock, false)
+        then:
+        2 * store.findById('c1') >>> [Optional.of(st), Optional.of(st.started())]
+        1 * store.save({ it.status() == CommandStatus.RUNNING })
+        1 * store.save({ it.status() == CommandStatus.SUCCEEDED })
+        1 * lock.release()
+        !svc.@inFlight.contains('c1')
+    }
+
+    def 'runCommand: a RUNNING result leaves the command RUNNING with no terminal write'() {
+        given:
+        def h = new ExternalJobHandler()
+        def reg = CommandRegistration.of(h)
+        def lock = Mock(Lock)
+        svc.@inFlight.add('c1')
+        when:
+        svc.runCommand('c1', reg, lock, false)
+        then:
+        _ * store.findById('c1') >> Optional.of(submitted('c1'))
+        1 * store.save({ it.status() == CommandStatus.RUNNING })
+        0 * store.save({ it.status() == CommandStatus.SUCCEEDED })
+        0 * store.save({ it.status() == CommandStatus.FAILED })
+        1 * lock.release()
+        h.executeCalled
+        !svc.@inFlight.contains('c1')
+    }
+
+    def 'runCommand: CHECK_STATUS polls checkStatus and applies a terminal result'() {
+        given:
+        def h = new ExternalJobHandler()
+        def reg = CommandRegistration.of(h)
+        def lock = Mock(Lock)
+        def rs = running('c1')
+        when:
+        svc.runCommand('c1', reg, lock, true)
+        then:
+        _ * store.findById('c1') >> Optional.of(rs)
+        0 * store.save({ it.status() == CommandStatus.RUNNING })
+        1 * store.save({ it.status() == CommandStatus.SUCCEEDED })
+        1 * lock.release()
+        h.checkStatusCalled
+        !h.executeCalled
+    }
+
+    def 'runCommand: a throwing handler marks FAILED and releases the lock'() {
+        given:
+        def reg = CommandRegistration.of(new FailingHandler())
+        def lock = Mock(Lock)
+        svc.@inFlight.add('c1')
+        def st = submitted('c1')
+        when:
+        svc.runCommand('c1', reg, lock, false)
+        then:
+        2 * store.findById('c1') >>> [Optional.of(st), Optional.of(st.started())]
+        1 * store.save({ it.status() == CommandStatus.RUNNING })
+        1 * store.save({ it.status() == CommandStatus.FAILED && it.error() == 'boom' })
+        1 * lock.release()
+        !svc.@inFlight.contains('c1')
+    }
+
+    def 'runCommand: does not clobber a CANCELLED observed at the terminal re-read'() {
+        given:
+        def reg = CommandRegistration.of(new InProcHandler())
+        def lock = Mock(Lock)
+        def st = submitted('c1')
+        when:
+        svc.runCommand('c1', reg, lock, false)
+        then:
+        2 * store.findById('c1') >>> [Optional.of(st), Optional.of(st.cancelled())]
+        1 * store.save({ it.status() == CommandStatus.RUNNING })
+        0 * store.save({ it.status() == CommandStatus.SUCCEEDED })
+        1 * lock.release()
+    }
+
+    def 'runCommand: skips execution when already terminal before start'() {
+        given:
+        def reg = CommandRegistration.of(new InProcHandler())
+        def lock = Mock(Lock)
+        svc.@inFlight.add('c1')
+        when:
+        svc.runCommand('c1', reg, lock, false)
+        then:
+        1 * store.findById('c1') >> Optional.of(submitted('c1').cancelled())
+        0 * store.save(_)
+        1 * lock.release()
+        !svc.@inFlight.contains('c1')
+    }
+
+    // ---- B1 ordering: in-flight registered before dispatch (no leak) ----
+
+    def 'no in-flight leak when the worker completes synchronously during dispatch'() {
+        given: 'an inline executor that runs the task within pool.execute() (worker finishes before processCommand returns)'
+        svc.registerHandler(new InProcHandler())
+        def lock = Mock(Lock)
+        svc.@pool = { Runnable r -> r.run() } as ExecutorService
+        def st = submitted('c1')
+        when:
+        def ack = svc.processCommand(CommandMsg.of('c1', 'test'))
+        then:
+        _ * store.findById('c1') >> Optional.of(st)
+        1 * lockManager.tryAcquire(_) >> lock
+        1 * lock.release()
+        !ack
+        // add-before-submit ordering means the worker's finally removed the entry it saw registered
+        !svc.@inFlight.contains('c1')
+    }
+
+    // ---- pool lifecycle ----
+
+    def 'stop() shuts down and terminates the worker pool'() {
+        given:
+        svc.@queue = Mock(CommandQueue)
+        when:
+        svc.start()
+        then:
+        svc.@pool != null
+        when:
+        svc.stop()
+        then:
+        svc.@pool.isShutdown()
+        svc.@pool.isTerminated()
+    }
+
+    // ---- handler discrimination ----
+
+    def 'detects whether a handler overrides checkStatus'() {
+        expect:
+        CommandServiceImpl.overridesCheckStatus(new ExternalJobHandler())
+        !CommandServiceImpl.overridesCheckStatus(new InProcHandler())
+    }
+}
+
+// ---- test handlers ----
+
+class InProcHandler implements CommandHandler<TestParams, TestResult> {
+    @Override String type() { 'test' }
+    @Override CommandResult<TestResult> execute(Command<TestParams> command) {
+        return CommandResult.success(new TestResult('done', command.params().value))
+    }
+}
+
+class ExternalJobHandler implements CommandHandler<TestParams, TestResult> {
+    boolean executeCalled
+    boolean checkStatusCalled
+    @Override String type() { 'test' }
+    @Override CommandResult<TestResult> execute(Command<TestParams> command) {
+        executeCalled = true
+        return CommandResult.running()
+    }
+    @Override CommandResult<TestResult> checkStatus(Command<TestParams> command, CommandState state) {
+        checkStatusCalled = true
+        return CommandResult.success(new TestResult('slow', command.params().value))
+    }
+}
+
+class FailingHandler implements CommandHandler<TestParams, TestResult> {
+    @Override String type() { 'test' }
+    @Override CommandResult<TestResult> execute(Command<TestParams> command) {
+        throw new RuntimeException('boom')
+    }
+}

--- a/lib-cmd-queue-redis/src/test/groovy/io/seqera/data/command/CommandServiceRedisTest.groovy
+++ b/lib-cmd-queue-redis/src/test/groovy/io/seqera/data/command/CommandServiceRedisTest.groovy
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.seqera.data.command
+
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+
+import com.github.f4b6a3.tsid.TsidCreator
+import io.micronaut.context.ApplicationContext
+import io.seqera.data.command.store.CommandStateStore
+import io.seqera.fixtures.redis.RedisTestContainer
+import io.seqera.lock.Lock
+import io.seqera.lock.LockManager
+import redis.clients.jedis.JedisPool
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+/**
+ * Redis-backed integration tests (Testcontainers) proving the async design's distributed guarantees:
+ * non-blocking intake, single concurrent runner across replicas, crash recovery, and ack-on-reclaim.
+ */
+class CommandServiceRedisTest extends Specification implements RedisTestContainer {
+
+    def setup() {
+        // isolate each test: wipe streams, state and locks from any previous test
+        def pool = new JedisPool(System.getProperty('redis.host'), Integer.parseInt(System.getProperty('redis.port')))
+        try {
+            pool.resource.withCloseable { it.flushAll() }
+        } finally {
+            pool.close()
+        }
+    }
+
+    /**
+     * A replica context bound to the test Redis. Setting {@code redis.uri} selects the Redis state
+     * provider (excludes the local one, whose {@code @Requires(missingProperty='redis.uri')} would
+     * otherwise make the {@code StateProvider} injection ambiguous).
+     */
+    private static ApplicationContext newContext() {
+        def uri = "redis://${System.getProperty('redis.host')}:${System.getProperty('redis.port')}".toString()
+        return ApplicationContext.run(['redis.uri': uri], 'test', 'redis')
+    }
+
+    private static String tsid() {
+        TsidCreator.getTsid().toLowerCase()
+    }
+
+    private static TestCommand cmd(String id, String mode, int value = 1) {
+        new TestCommand(id, 'test', new TestParams(value, mode))
+    }
+
+    def 'does not block intake: a short command completes while a long one is still running'() {
+        given:
+        def ctx = newContext()
+        def svc = ctx.getBean(CommandService)
+        svc.registerHandler(new ModeHandler())
+        svc.start()
+        def longId = tsid()
+        def shortId = tsid()
+
+        when: 'a long in-process command is submitted, then a short one'
+        svc.submit(cmd(longId, 'slow'))
+        sleep(200)
+        svc.submit(cmd(shortId, 'fast', 2))
+
+        then: 'the short command finishes while the long one is still running'
+        new PollingConditions(timeout: 8).eventually {
+            assert svc.getState(shortId).get().status() == CommandStatus.SUCCEEDED
+        }
+        svc.getState(longId).get().status() == CommandStatus.RUNNING
+
+        cleanup:
+        ctx?.stop()
+    }
+
+    def 'runs a command exactly once across two replicas sharing one Redis'() {
+        given: 'two independent service instances (replicas) against the same Redis'
+        def runs = new AtomicInteger()
+        def ctxA = newContext()
+        def ctxB = newContext()
+        def svcA = ctxA.getBean(CommandServiceImpl)
+        def svcB = ctxB.getBean(CommandServiceImpl)
+        // instrument each replica's lock so we can prove exclusion was lock-mediated, not just
+        // "the message was never redelivered to the other replica" (spec §6.18)
+        def lockA = new CountingLockManager(svcA.@lockManager)
+        def lockB = new CountingLockManager(svcB.@lockManager)
+        svcA.@lockManager = lockA
+        svcB.@lockManager = lockB
+        // in-process handler (no checkStatus override) sleeping past the 1s claim timeout, so the
+        // other replica WILL reclaim the unacked message mid-run; only the single-runner lock can
+        // stop it re-executing (each replica has its own, empty, in-flight set)
+        svcA.registerHandler(new CountingHandler(runs, 3000))
+        svcB.registerHandler(new CountingHandler(runs, 3000))
+        svcA.start()
+        svcB.start()
+        def id = tsid()
+
+        when:
+        svcA.submit(cmd(id, 'x'))
+
+        then: 'it completes'
+        new PollingConditions(timeout: 20).eventually {
+            assert svcA.getState(id).get().status() == CommandStatus.SUCCEEDED
+        }
+
+        and: 'execute() ran exactly once despite the cross-replica reclaim'
+        sleep(2000)
+        runs.get() == 1
+
+        and: 'both replicas attempted the lock and the loser was refused (lock-mediated exclusion)'
+        (lockA.tryAcquireCalls.get() + lockB.tryAcquireCalls.get()) >= 2
+        (lockA.nullReturns.get() + lockB.nullReturns.get()) >= 1
+
+        cleanup:
+        ctxA?.stop()
+        ctxB?.stop()
+    }
+
+    def 'recovers a command left RUNNING by a crashed replica (no lock held)'() {
+        given:
+        def runs = new AtomicInteger()
+        def ctx = newContext()
+        def svc = ctx.getBean(CommandService)
+        def store = ctx.getBean(CommandStateStore)
+        def queue = ctx.getBean(CommandQueue)
+        svc.registerHandler(new CountingHandler(runs, 0))
+        svc.start()
+
+        and: 'a command previously marked RUNNING by a since-dead replica, with no lock held'
+        def id = tsid()
+        store.save(CommandState.submitted(id, 'test', new TestParams(5, 'x')).started())
+        queue.submit(CommandMsg.of(id, 'test'))
+
+        expect: 'a fresh delivery re-runs execute() to completion (in-process crash recovery)'
+        new PollingConditions(timeout: 12).eventually {
+            assert svc.getState(id).get().status() == CommandStatus.SUCCEEDED
+        }
+        runs.get() == 1
+
+        cleanup:
+        ctx?.stop()
+    }
+
+    def 'acknowledges (removes) the stream entry after completion via reclaim'() {
+        given:
+        def ctx = newContext()
+        def svc = ctx.getBean(CommandService)
+        def queue = ctx.getBean(CommandQueue)
+        svc.registerHandler(new CountingHandler(new AtomicInteger(), 0))
+        svc.start()
+        def id = tsid()
+
+        when:
+        svc.submit(cmd(id, 'x'))
+
+        then: 'command completes'
+        new PollingConditions(timeout: 12).eventually {
+            assert svc.getState(id).get().status() == CommandStatus.SUCCEEDED
+        }
+
+        and: 'the lingering unacked entry is reclaimed and removed within ~claimTimeout'
+        new PollingConditions(timeout: 12).eventually {
+            assert queue.length() == 0
+        }
+
+        cleanup:
+        ctx?.stop()
+    }
+}
+
+// ---- integration test handlers ----
+
+class ModeHandler implements CommandHandler<TestParams, TestResult> {
+    @Override String type() { 'test' }
+    @Override CommandResult<TestResult> execute(Command<TestParams> command) {
+        if (command.params().mode == 'slow') {
+            Thread.sleep(3000)
+        }
+        return CommandResult.success(new TestResult('ok', command.params().value))
+    }
+}
+
+/** LockManager decorator recording how many times tryAcquire ran and how often it was refused. */
+class CountingLockManager implements LockManager {
+    private final LockManager delegate
+    final AtomicInteger tryAcquireCalls = new AtomicInteger()
+    final AtomicInteger nullReturns = new AtomicInteger()
+
+    CountingLockManager(LockManager delegate) {
+        this.delegate = delegate
+    }
+
+    @Override
+    Lock tryAcquire(String lockKey) {
+        tryAcquireCalls.incrementAndGet()
+        def lock = delegate.tryAcquire(lockKey)
+        if (lock == null) {
+            nullReturns.incrementAndGet()
+        }
+        return lock
+    }
+
+    @Override
+    Lock acquire(String lockKey, Duration timeout) {
+        return delegate.acquire(lockKey, timeout)
+    }
+}
+
+class CountingHandler implements CommandHandler<TestParams, TestResult> {
+    private final AtomicInteger runs
+    private final long sleepMs
+
+    CountingHandler(AtomicInteger runs, long sleepMs) {
+        this.runs = runs
+        this.sleepMs = sleepMs
+    }
+
+    @Override String type() { 'test' }
+    @Override CommandResult<TestResult> execute(Command<TestParams> command) {
+        runs.incrementAndGet()
+        if (sleepMs > 0) {
+            Thread.sleep(sleepMs)
+        }
+        return CommandResult.success(new TestResult('ok', command.params().value))
+    }
+}


### PR DESCRIPTION
## Summary

Extends `lib-cmd-queue-redis` to process queued commands on a **bounded worker pool** instead of serially on the single poll thread, so multiple commands run concurrently and the poll thread never blocks on a handler — while guaranteeing a command's handler is **not run concurrently on more than one replica** (exactly-once-ish: single concurrent runner, at-least-once on crash).

Design spec: `docs/superpowers/specs/2026-07-01-async-command-processing-design.md`.

## How it works

- **Non-blocking dispatch** — `processCommand` (poll thread) hands each command to a bounded `ExecutorService` and returns immediately; `runCommand` runs the handler to completion on a worker.
- **Single concurrent runner across replicas** — a per-command distributed lock (`lib-lock` `tryAcquire` + watchdog). The lock is auto-renewed while the holder is alive and expires by TTL on crash (no hand-rolled heartbeat). Same-replica dedup via an in-flight `Set` registered **before** dispatch. In non-Redis mode an in-JVM lock is selected automatically.
- **Ack-on-reclaim** — the worker never acks; a finished command's stream entry is removed on the next reclaim once the store shows a terminal state, so the shared `lib-data-stream-redis` interface is **untouched**. Result is visible in the store immediately; only the (harmless) stream entry lingers up to one claim timeout.
- **Backpressure** — bounded pool queue; a rejected command is left queued and retried on a later delivery.

## Backward compatibility

- The `execute()` → `running()` + `checkStatus()` **external-job pattern is preserved** (handlers overriding `checkStatus` are polled; in-process handlers re-run on crash recovery).
- `executeTimeout()` retained and `@Deprecated` (no longer consulted); new `CommandConfig` methods are `default`s.
- No change to `MessageStream`/`AbstractMessageStream`/`RedisMessageStream`.

New deps: `lib-lock`, `lib-lock-redis`, `lib-activator`, `redis.clients:jedis`.

## Testing — 36 tests, all green

- 15 existing (no regression, incl. the `slow`/`checkStatus` scenario) · 17 new unit · 4 Testcontainers integration.
- Integration (real Redis, 1s claim timeout) proves: **single-runner across two replicas** (loser reclaims the in-flight message and is refused the lock — asserted via a counting lock delegate), crash-recovery re-run, ack-on-reclaim, and non-blocking intake.

## Review

Went through two adversarial review passes (spec + code). All spec-review blockers were fixed and verified; the code review found no blockers.

## Not included (release steps)

`README.md` / `changelog.txt` / `VERSION` bump — left for a separate release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
