### PR TITLE
fix(lib-cloudinfo): narrow unconfigured-provider test to sched filter

### DIFF
--- a/lib-cloudinfo/src/test/groovy/io/seqera/cloudinfo/client/CloudInfoClientTest.groovy
+++ b/lib-cloudinfo/src/test/groovy/io/seqera/cloudinfo/client/CloudInfoClientTest.groovy
@@ -98,9 +98,14 @@ class CloudInfoClientTest extends Specification {
         filtered.every { allTypes.contains(it.type) }
     }
 
-    def 'should return all products for unconfigured provider when filters set'() {
+    def 'should return all products for a provider without a sched allowlist'() {
         given:
-        def query = ProductsQuery.builder().sched(true).nvme(true).build()
+        // sched is a curated allowlist configured only for amazon; a provider
+        // without one (google) treats the sched filter as unknown/no-op and
+        // returns all products. Only sched behaves this way: derived features
+        // such as nvme/ssd genuinely narrow the result, so they are not asserted
+        // here (see the amazon nvme=true subset test above).
+        def query = ProductsQuery.builder().sched(true).build()
 
         when:
         def all = client.getProducts('google', 'us-central1')


### PR DESCRIPTION
## What

Narrows the `CloudInfoClient` integration test `should return all products for
unconfigured provider when filters set` to the **sched filter only**.
**Pure test fix — no library code and no version change.**

## Why

The test runs as part of `./gradlew check`, so it was failing every PR's CI. It
looked like flakiness but was a deterministic external-API change:

1. The `cloudinfo` service's COMP-1801 refactor routed `?sched=true` through a
   strict feature filter. `sched` is a curated **amazon-only** allowlist, so
   `google ?sched=true` flipped from "all products" to **0** — a real regression,
   fixed and deployed in **seqeralabs/cloudinfo#64** (`google ?sched=true` → all
   again).
2. The same refactor made `nvme`→`ssd` a **provider-derived** feature.
   `google ?nvme=true` now legitimately returns a real subset (393 of 2157) —
   correct behaviour, not a bug.

The test asserted `filtered.size() == all.size()` with **both** `sched(true)` and
`nvme(true)`. Even with the sched regression fixed, the `nvme`/`ssd` half
correctly narrows google, so the equality can never hold again. The premise
("both filters are no-ops for google") is only valid for `sched`.

## Change

Drop `.nvme(true)` so the test asserts exactly the restored contract: a provider
with no `sched` allowlist returns all products. The `nvme`/`ssd` subset behaviour
is already covered by the amazon `nvme=true` subset test. Verified green against
the live (post-#64) API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
