### PR TITLE
ci(release): gate publishing to master merges only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,10 +59,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
 
       - name: Release
-        # Only release from master, which is protected and updated exclusively via
-        # merged PRs. publish.sh is idempotent (skips versions already in the repo),
-        # so a release happens only when a merged PR bumps a module's VERSION file.
-        if: "github.ref == 'refs/heads/master'"
+        # Release only from master (protected, updated exclusively via merged PRs)
+        # AND when the merge commit is explicitly marked [release]. publish.sh is
+        # idempotent (skips versions already in the repo), so a bumped VERSION file
+        # still gates what actually publishes.
+        if: "github.ref == 'refs/heads/master' && contains(github.event.head_commit.message, '[release]')"
         run: |
           bash publish.sh lib-jedis-lock
           bash publish.sh lib-activator

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
 
       - name: Release
-        if: "contains(github.event.head_commit.message, '[release]')"
+        # Only release from master, which is protected and updated exclusively via
+        # merged PRs. publish.sh is idempotent (skips versions already in the repo),
+        # so a release happens only when a merged PR bumps a module's VERSION file.
+        if: "github.ref == 'refs/heads/master'"
         run: |
           bash publish.sh lib-jedis-lock
           bash publish.sh lib-activator

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,6 @@ This is a library collection (`libseqera`) containing reusable components for Se
 Libraries are published to Seqera's private Maven repository on S3 using AWS credentials.
 
 ### Release Management
-- Releases run only on pushes to `master` (protected, updated exclusively via merged PRs)
-- To release a module, bump its `VERSION` file in a PR; merging to `master` publishes it
-- `publish.sh` is idempotent — it skips any version already in the repo, so only bumped `VERSION` files are published; no commit-message marker is required
+- Releases run only on pushes to `master` (protected, updated exclusively via merged PRs) whose merge commit message contains the `[release]` marker
+- To release a module: bump its `VERSION` file in a PR and include `[release]` in the PR title / merge commit; merging to `master` publishes it
+- `publish.sh` is idempotent — it skips any version already in the repo, so only bumped `VERSION` files are actually published

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,5 +83,6 @@ This is a library collection (`libseqera`) containing reusable components for Se
 Libraries are published to Seqera's private Maven repository on S3 using AWS credentials.
 
 ### Release Management
-- Use `[release]` as prefix in the first line of commit messages to trigger module library releases
-- The release automation will detect this prefix and initiate the publishing process for updated modules
+- Releases run only on pushes to `master` (protected, updated exclusively via merged PRs)
+- To release a module, bump its `VERSION` file in a PR; merging to `master` publishes it
+- `publish.sh` is idempotent — it skips any version already in the repo, so only bumped `VERSION` files are published; no commit-message marker is required


### PR DESCRIPTION
## Problems

The `Release` step in `.github/workflows/build.yml` had **no branch guard** — its only condition was `contains(github.event.head_commit.message, '[release]')`. Combined with the `on: push: branches: ['**']` trigger, **any push to any branch** with `[release]` in the head commit ran `publish.sh` and could publish artifacts. This creates two distinct problems.

### 1. Audit gap — releases without approval

Anyone with push access could cut a release from a feature branch, with no PR review. Verified in run history — releases were in fact firing from feature branches before merge:

| Run | Branch | Release step |
|---|---|---|
| `28860427327` | `feature/NOTASK-lib-cloudinfo-gpu-features` | ✅ ran |
| `28858278102` | `fix/NOTASK-lib-cloudinfo-sched-passthrough-test` | ✅ ran |
| `28869154215` | `bump-cloudinfo-version` | ✅ ran |

### 2. Error-prone — publishing before review completes

Because the release fires on the pre-merge push rather than on merge, a version can be **published from code that review then changes**. Review comments refine the code, but the artifact for that version was already burned on the earlier push. And since `publish.sh` is idempotent (it skips any `name-version.pom` already in the repo), when the refined code finally merges to `master` it finds the version already exists and **skips** it — so **the reviewed, merged code is never published under that version**. The published artifact silently diverges from what was reviewed and merged.

Circumstantial evidence this already happened: `lib-cloudinfo` `v1.2.1` ran as `[release] … GpuFeatures … v1.2.1` on the feature branch, but the code that merged to `master` was `AcceleratorFeatures … v1.2.1` — same version, renamed API. If `v1.2.1` was published from the earlier feature-branch run, the master merge would have skipped it, leaving the pre-rename `GpuFeatures` build published as `v1.2.1`. (Not log-confirmed — the feature-branch run logs weren't retrievable — but consistent with the run ordering and `publish.sh`'s skip-if-exists logic.)

## Change

Add a `master` branch guard to the existing `[release]` marker check — **both** must hold:

```yaml
if: "github.ref == 'refs/heads/master' && contains(github.event.head_commit.message, '[release]')"
```

- **`master` gate:** `master` is protected and updated exclusively via merged PRs, so releases now require an **approved, merged PR**, and the publish runs against the **final, reviewed** code — not a mid-review snapshot.
- **`[release]` marker kept:** an explicit per-merge opt-in. The marker must be present in the *merge commit* message (i.e. the squash/PR title, which today already carries it — e.g. `[release] Bump cloudinfo library (#80)`).

A release therefore requires three things to align: push to `master` + `[release]` in the merge commit + a bumped `VERSION` (only new versions publish, since `publish.sh` skips ones already in the repo).

## Behavior after this change

- Release only when **merging to `master`**, the merge commit contains **`[release]`**, and a module's **`VERSION` was increased**.
- No release from feature branches, no release without a merged PR, and the published artifact matches the reviewed/merged code.
- A `VERSION` bump can still be merged *without* publishing by omitting `[release]` from the merge commit.

## Docs

`CLAUDE.md` Release Management section updated to describe the new flow (bump `VERSION` + `[release]` in the PR title → merge to `master`).

## Note

Opened as **draft** for review. No Jira ticket (NOTASK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
