### PR TITLE
build(java): align toolchain and runtime to Java 25 (bytecode 17)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{matrix.java_version}}
-          distribution: 'adopt'
+          distribution: 'corretto'
           architecture: x64
           cache: gradle
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [21]
+        java_version: [25]
 
     steps:
       - name: Environment

--- a/.github/workflows/generate-submit-dependencies.yml
+++ b/.github/workflows/generate-submit-dependencies.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
       with:
-        distribution: temurin
+        distribution: corretto
         java-version: 17
 
     - name: Generate and submit dependency graph for libseqera

--- a/.github/workflows/generate-submit-dependencies.yml
+++ b/.github/workflows/generate-submit-dependencies.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
       with:
         distribution: corretto
-        java-version: 17
+        java-version: 25
 
     - name: Generate and submit dependency graph for libseqera
       uses: gradle/actions/dependency-submission@ed408507eac070d1f99cc633dbcf757c94c7933a # v4

--- a/buildSrc/src/main/groovy/io.seqera.groovy-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.seqera.groovy-common-conventions.gradle
@@ -35,8 +35,8 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(25)
     }
-    sourceCompatibility = 25
-    targetCompatibility = 25
+    sourceCompatibility = 17
+    targetCompatibility = 17
 }
 
 group = 'io.seqera'

--- a/buildSrc/src/main/groovy/io.seqera.groovy-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.seqera.groovy-common-conventions.gradle
@@ -35,8 +35,8 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(25)
     }
-    sourceCompatibility = 17
-    targetCompatibility = 17
+    sourceCompatibility = 25
+    targetCompatibility = 25
 }
 
 group = 'io.seqera'

--- a/buildSrc/src/main/groovy/io.seqera.groovy-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.seqera.groovy-common-conventions.gradle
@@ -33,7 +33,7 @@ repositories {
 java {
     // these settings apply to all jvm tooling, including groovy
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
     sourceCompatibility = 17
     targetCompatibility = 17

--- a/buildSrc/src/main/groovy/io.seqera.groovy-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.seqera.groovy-library-conventions.gradle
@@ -28,7 +28,7 @@ plugins {
 }
 
 dependencies {
-    implementation "org.apache.groovy:groovy:4.0.24"
+    implementation "org.apache.groovy:groovy:4.0.31"
 }
 
 group = 'io.seqera'

--- a/buildSrc/src/main/groovy/io.seqera.java-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.seqera.java-library-conventions.gradle
@@ -61,6 +61,8 @@ dependencies {
     testImplementation "org.objenesis:objenesis:3.4"
     testImplementation "org.spockframework:spock-core:2.3-groovy-4.0"
     testImplementation "org.spockframework:spock-junit4:2.3-groovy-4.0"
+    // Gradle 9 no longer provides the JUnit Platform launcher automatically
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.5'
 }
 
 tasks.withType(Test) {

--- a/buildSrc/src/main/groovy/io.seqera.java-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.seqera.java-library-conventions.gradle
@@ -35,8 +35,8 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(25)
     }
-    sourceCompatibility = 17
-    targetCompatibility = 17
+    sourceCompatibility = 25
+    targetCompatibility = 25
 }
 
 test {

--- a/buildSrc/src/main/groovy/io.seqera.java-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.seqera.java-library-conventions.gradle
@@ -33,7 +33,7 @@ repositories {
 java {
     // these settings apply to all jvm tooling, including groovy
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
     sourceCompatibility = 17
     targetCompatibility = 17

--- a/buildSrc/src/main/groovy/io.seqera.java-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.seqera.java-library-conventions.gradle
@@ -54,9 +54,9 @@ dependencies {
 
     testImplementation 'ch.qos.logback:logback-core:1.5.25'
     testImplementation 'ch.qos.logback:logback-classic:1.5.25'
-    testImplementation "org.apache.groovy:groovy:4.0.24"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.24"
-    testImplementation "org.apache.groovy:groovy-test:4.0.24"
+    testImplementation "org.apache.groovy:groovy:4.0.31"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
+    testImplementation "org.apache.groovy:groovy-test:4.0.31"
     testImplementation "cglib:cglib-nodep:3.3.0"
     testImplementation "org.objenesis:objenesis:3.4"
     testImplementation "org.spockframework:spock-core:2.3-groovy-4.0"

--- a/buildSrc/src/main/groovy/io.seqera.java-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.seqera.java-library-conventions.gradle
@@ -35,8 +35,8 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(25)
     }
-    sourceCompatibility = 25
-    targetCompatibility = 25
+    sourceCompatibility = 17
+    targetCompatibility = 17
 }
 
 test {

--- a/buildSrc/src/main/groovy/io.seqera.java-test-fixtures-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.seqera.java-test-fixtures-conventions.gradle
@@ -63,4 +63,6 @@ dependencies {
     testFixturesImplementation "org.objenesis:objenesis:3.4"
     testFixturesImplementation "org.spockframework:spock-core:2.3-groovy-4.0"
     testFixturesImplementation "org.spockframework:spock-junit4:2.3-groovy-4.0"
+    // Gradle 9 no longer provides the JUnit Platform launcher automatically
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.5'
 }

--- a/buildSrc/src/main/groovy/io.seqera.java-test-fixtures-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.seqera.java-test-fixtures-conventions.gradle
@@ -56,9 +56,9 @@ dependencies {
 
     testFixturesImplementation 'ch.qos.logback:logback-core:1.5.25'
     testFixturesImplementation 'ch.qos.logback:logback-classic:1.5.25'
-    testFixturesImplementation "org.apache.groovy:groovy:4.0.24"
-    testFixturesImplementation "org.apache.groovy:groovy-nio:4.0.24"
-    testFixturesImplementation "org.apache.groovy:groovy-test:4.0.24"
+    testFixturesImplementation "org.apache.groovy:groovy:4.0.31"
+    testFixturesImplementation "org.apache.groovy:groovy-nio:4.0.31"
+    testFixturesImplementation "org.apache.groovy:groovy-test:4.0.31"
     testFixturesImplementation "cglib:cglib-nodep:3.3.0"
     testFixturesImplementation "org.objenesis:objenesis:3.4"
     testFixturesImplementation "org.spockframework:spock-core:2.3-groovy-4.0"

--- a/buildSrc/src/main/groovy/io.seqera.java-test-fixtures-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.seqera.java-test-fixtures-conventions.gradle
@@ -37,8 +37,8 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(25)
     }
-    sourceCompatibility = 25
-    targetCompatibility = 25
+    sourceCompatibility = 17
+    targetCompatibility = 17
 }
 
 test {

--- a/buildSrc/src/main/groovy/io.seqera.java-test-fixtures-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.seqera.java-test-fixtures-conventions.gradle
@@ -37,8 +37,8 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(25)
     }
-    sourceCompatibility = 17
-    targetCompatibility = 17
+    sourceCompatibility = 25
+    targetCompatibility = 25
 }
 
 test {

--- a/buildSrc/src/main/groovy/io.seqera.java-test-fixtures-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.seqera.java-test-fixtures-conventions.gradle
@@ -35,7 +35,7 @@ repositories {
 java {
     // these settings apply to all jvm tooling, including groovy
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
     sourceCompatibility = 17
     targetCompatibility = 17

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -17,7 +17,7 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lib-data-broadcast-redis/build.gradle
+++ b/lib-data-broadcast-redis/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation "io.micronaut:micronaut-runtime:${micronautCoreVersion}"
 
     // Groovy dependencies only for tests
-    testImplementation "org.apache.groovy:groovy:4.0.24"
+    testImplementation "org.apache.groovy:groovy:4.0.31"
     testImplementation testFixtures(project(':lib-fixtures-redis'))
     testImplementation "io.micronaut:micronaut-inject-groovy:${micronautCoreVersion}"
     testImplementation "io.micronaut.test:micronaut-test-spock:${micronautTestVersion}"

--- a/lib-data-count-redis/build.gradle
+++ b/lib-data-count-redis/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation "io.micronaut:micronaut-runtime:${micronautCoreVersion}"
 
     testImplementation testFixtures(project(':lib-fixtures-redis'))
-    testImplementation "org.apache.groovy:groovy:4.0.24"
+    testImplementation "org.apache.groovy:groovy:4.0.31"
     testImplementation "io.micronaut:micronaut-inject-groovy:${micronautCoreVersion}"
     testImplementation "io.micronaut.test:micronaut-test-spock:${micronautTestVersion}"
     testImplementation 'org.testcontainers:testcontainers:1.21.4'

--- a/lib-data-queue-redis/build.gradle
+++ b/lib-data-queue-redis/build.gradle
@@ -35,9 +35,9 @@ dependencies {
 
     compileOnly "io.micronaut:micronaut-inject-groovy:${micronautCoreVersion}"
     implementation "ch.qos.logback:logback-classic:1.5.25"
-    implementation "org.apache.groovy:groovy:4.0.24"
-    implementation "org.apache.groovy:groovy-nio:4.0.24"
-    implementation "org.apache.groovy:groovy-templates:4.0.24"
+    implementation "org.apache.groovy:groovy:4.0.31"
+    implementation "org.apache.groovy:groovy-nio:4.0.31"
+    implementation "org.apache.groovy:groovy-templates:4.0.31"
     implementation "io.micronaut:micronaut-runtime:${micronautCoreVersion}"
     implementation "io.micronaut:micronaut-websocket:${micronautCoreVersion}"
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'

--- a/lib-data-range-redis/build.gradle
+++ b/lib-data-range-redis/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation "io.micronaut:micronaut-runtime:${micronautCoreVersion}"
 
     testImplementation testFixtures(project(':lib-fixtures-redis'))
-    testImplementation "org.apache.groovy:groovy:4.0.24"
+    testImplementation "org.apache.groovy:groovy:4.0.31"
     testImplementation "io.micronaut:micronaut-inject-groovy:${micronautCoreVersion}"
     testImplementation "io.micronaut.test:micronaut-test-spock:${micronautTestVersion}"
     testImplementation 'org.testcontainers:testcontainers:1.21.4'

--- a/lib-data-stream-redis/build.gradle
+++ b/lib-data-stream-redis/build.gradle
@@ -45,10 +45,10 @@ dependencies {
     testImplementation "io.micrometer:micrometer-core:1.12.4"
 
     // Groovy dependencies only for tests
-    testImplementation "org.apache.groovy:groovy:4.0.24"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.24"
-    testImplementation "org.apache.groovy:groovy-templates:4.0.24"
-    testImplementation "org.apache.groovy:groovy-json:4.0.24"
+    testImplementation "org.apache.groovy:groovy:4.0.31"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
+    testImplementation "org.apache.groovy:groovy-templates:4.0.31"
+    testImplementation "org.apache.groovy:groovy-json:4.0.31"
     testImplementation project(':lib-lang')
     testImplementation testFixtures(project(':lib-fixtures-redis'))
     testImplementation "io.micronaut:micronaut-inject-groovy:${micronautCoreVersion}"

--- a/lib-hashx/build.gradle
+++ b/lib-hashx/build.gradle
@@ -25,6 +25,6 @@ version = "${project.file('VERSION').text.trim()}"
 
 dependencies {
     // Test dependencies
-    testImplementation 'org.apache.groovy:groovy:4.0.24'
+    testImplementation 'org.apache.groovy:groovy:4.0.31'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
 }

--- a/lib-jedis-pool/build.gradle
+++ b/lib-jedis-pool/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     compileOnly "io.micrometer:micrometer-core:1.12.4"
     implementation "org.slf4j:slf4j-api:2.0.12"
 
-    testImplementation "org.apache.groovy:groovy:4.0.24"
+    testImplementation "org.apache.groovy:groovy:4.0.31"
     testImplementation "io.micronaut:micronaut-inject-groovy:${micronautCoreVersion}"
     testImplementation "io.micronaut.test:micronaut-test-spock:${micronautTestVersion}"
     testImplementation "io.micrometer:micrometer-core:1.12.4"

--- a/lib-mail/build.gradle
+++ b/lib-mail/build.gradle
@@ -26,9 +26,9 @@ plugins {
 dependencies {
     compileOnly "io.micronaut:micronaut-inject-groovy:${micronautCoreVersion}"
     implementation "ch.qos.logback:logback-classic:1.5.25"
-    implementation "org.apache.groovy:groovy:4.0.24"
-    implementation "org.apache.groovy:groovy-nio:4.0.24"
-    implementation "org.apache.groovy:groovy-templates:4.0.24"
+    implementation "org.apache.groovy:groovy:4.0.31"
+    implementation "org.apache.groovy:groovy-nio:4.0.31"
+    implementation "org.apache.groovy:groovy-templates:4.0.31"
     api "com.sun.mail:javax.mail:1.6.2"
     api "org.jsoup:jsoup:1.15.3"
     implementation("io.micronaut:micronaut-runtime:${micronautCoreVersion}")

--- a/lib-node-id-redis/build.gradle
+++ b/lib-node-id-redis/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     compileOnly "io.micronaut:micronaut-inject:${micronautCoreVersion}"
     implementation "org.slf4j:slf4j-api:2.0.12"
 
-    testImplementation "org.apache.groovy:groovy:4.0.24"
+    testImplementation "org.apache.groovy:groovy:4.0.31"
     testImplementation "io.micronaut:micronaut-inject-groovy:${micronautCoreVersion}"
     testImplementation "io.micronaut.test:micronaut-test-spock:${micronautTestVersion}"
     testImplementation testFixtures(project(':lib-fixtures-redis'))

--- a/lib-platform-oidc/build.gradle
+++ b/lib-platform-oidc/build.gradle
@@ -23,5 +23,5 @@ group = 'io.seqera'
 version = "${project.file('VERSION').text.trim()}"
 
 dependencies {
-    testImplementation "org.apache.groovy:groovy:4.0.24"
+    testImplementation "org.apache.groovy:groovy:4.0.31"
 }

--- a/lib-util-tsid/build.gradle
+++ b/lib-util-tsid/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     compileOnly "io.micronaut:micronaut-inject:${micronautCoreVersion}"
     implementation "org.slf4j:slf4j-api:2.0.12"
 
-    testImplementation "org.apache.groovy:groovy:4.0.24"
+    testImplementation "org.apache.groovy:groovy:4.0.31"
     testImplementation "io.micronaut:micronaut-inject-groovy:${micronautCoreVersion}"
     testImplementation "io.micronaut.test:micronaut-test-spock:${micronautTestVersion}"
 }


### PR DESCRIPTION
## Summary

Aligns this repository with the proposed org-wide Java 25 standard (implements https://github.com/seqeralabs/adr/pull/48). Java 25 is adopted as the build toolchain and runtime, while the language level and bytecode target remain at Java 17.

## What changed

- `buildSrc` convention plugins — bumped the Gradle Java toolchain from `JavaLanguageVersion.of(21)` to `of(25)` in all three convention files:
  - `io.seqera.java-library-conventions.gradle`
  - `io.seqera.java-test-fixtures-conventions.gradle`
  - `io.seqera.groovy-common-conventions.gradle`
- `.github/workflows/build.yml` — CI build matrix `java_version: [21]` -> `[25]`.
- `sourceCompatibility` / `targetCompatibility` left at `17` in all convention files (bytecode target unchanged).
- `.github/workflows/generate-submit-dependencies.yml` left at `java-version: 17` (dependency-submission job, unchanged).

## Why

Follows the proposed org-wide standard in the Java 25 ADR (seqeralabs/adr#48), which supersedes the 2024-12-03 Java 17/21 ADR. Building and running on the latest LTS while keeping the bytecode target at Java 17 preserves runtime compatibility for consumers.

## How to verify

- `./gradlew check` and `./gradlew assemble` build with a Java 25 toolchain.
- Compiled classes still target bytecode 17 (e.g. `javap -v` reports major version 61 / `class file version 61.0`).
- CI `build.yml` runs on Java 25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
