### PR TITLE
[release] ci: publish lib-data-workqueue(-redis) in the release step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,8 @@ jobs:
           bash publish.sh lib-data-store-future-redis
           bash publish.sh lib-data-store-state-redis
           bash publish.sh lib-data-stream-redis
+          bash publish.sh lib-data-workqueue
+          bash publish.sh lib-data-workqueue-redis
           bash publish.sh lib-fixtures-redis
           bash publish.sh lib-hashx
           bash publish.sh lib-lang


### PR DESCRIPTION
## Problem

PR #86 merged with `[release]` and CI went **green**, but `lib-data-workqueue:1.0.0` and `lib-data-workqueue-redis:1.0.0` were **never published** to the Maven repo. Downstream resolution fails (e.g. seqeralabs/sched#681 cannot resolve the two modules).

## Cause

The `Release` step in `.github/workflows/build.yml` publishes a **hardcoded list** of `bash publish.sh <module>` calls. The two modules added in #86 were never added to that list, so the publish loop skipped them silently — the step still succeeds.

## Fix

Add both modules to the publish loop, next to `lib-data-stream-redis`. `publish.sh` is idempotent (skips versions already in the repo), so merging this with `[release]` publishes only the two missing `1.0.0` artifacts and republishes nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
