### PR TITLE
Fix stale terminology in workqueue READMEs

### DIFF
--- a/lib-cmd-queue-redis/README.md
+++ b/lib-cmd-queue-redis/README.md
@@ -225,13 +225,13 @@ A quick command finishes in one delivery; a slow or external one flips to `PROCE
 and is driven to completion by repeated `checkStatus()` calls at `pollInterval`
 cadence. Handler exceptions transition the command to `FAILED` and ack. There is no
 per-command timeout and no per-command lock — the handler runs to completion on a
-virtual thread, and the underlying stream's per-message lease guarantees a single
+virtual thread, and the underlying work queue's per-message lease guarantees a single
 concurrent runner across replicas (see
 [`lib-data-workqueue-redis`](../lib-data-workqueue-redis/README.md)).
 
 ### Multi-replica behaviour
 
-The stream's per-message lease (a heartbeated Redis consumer-group entry) ensures a
+The work queue's per-message lease (a heartbeated Redis consumer-group entry) ensures a
 command is processed by exactly one live replica at a time; if that replica dies, the
 lease lapses and a peer reclaims the command. The store is the shared source of truth,
 so the terminal-state check keeps processing idempotent. Delivery is **at-least-once**,

--- a/lib-data-workqueue/README.md
+++ b/lib-data-workqueue/README.md
@@ -142,13 +142,14 @@ workQueue.offer("user-activity", event)
 // Consume events
 class ActivityConsumer implements MessageConsumer<ActivityEvent> {
     @Override
-    boolean consume(ActivityEvent event) {
+    boolean accept(ActivityEvent event) {
         analyticsService.recordActivity(event)
         return true // Acknowledge message
     }
 }
 
-workQueue.consume("user-activity", new ActivityConsumer())
+// Register the consumer; the queue dispatches messages to it asynchronously
+workQueue.addConsumer("user-activity", new ActivityConsumer())
 ```
 
 ## Architecture


### PR DESCRIPTION
## Summary
Docs-only. Aligns two READMEs with the current source after the 0.7.0 / 1.0.0 work-queue rename.

- **lib-cmd-queue-redis/README.md**: two leftover "stream" references → "work queue" (the 0.7.0 `MessageStream`→`WorkQueue` rename).
- **lib-data-workqueue/README.md**: usage example used a non-existent API:
  - `MessageConsumer.consume(...)` → `accept(...)` (actual interface method)
  - `workQueue.consume(...)` → `addConsumer(...)` (the async dispatch registration the doc describes; `consume()` is only a one-shot synchronous pull)

lib-data-workqueue-redis/README.md was checked and needed no changes.

## Test plan
Documentation only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)