### PR TITLE
ci(claude): add the Claude PR assistant with approving reviews

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,85 @@
+name: Claude PR Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude-code-action:
+    # The actor guard breaks the feedback loop: this workflow fires on
+    # pull_request_review, and Claude's own review body usually echoes the
+    # @claude mention that triggered it.
+    if: |
+      (github.actor != 'claude[bot]') && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude PR Action
+        uses: anthropics/claude-code-action@9db594c7a0e82298c121c18b7f08aa1579ce7341 # ratchet:anthropics/claude-code-action@v1.0.185
+        timeout-minutes: 60
+        with:
+          anthropic_api_key: ${{ secrets.ENG_ANTHROPIC_API_KEY }}
+          use_sticky_comment: true
+          # The action deliberately ships no review-submitting MCP tool, so a
+          # formal review can only be filed through the gh CLI — and tag mode
+          # allows no Bash beyond git, hence the explicit allowlist. Keep it to
+          # these four: a blanket Bash(gh api:*) would grant write access to
+          # every GitHub endpoint. --append-system-prompt (not --system-prompt,
+          # which would discard Claude Code's built-in prompt) lifts the default
+          # refusal to approve. The rubric approves by default and reserves the
+          # human for the four cases a bot verdict cannot cover: core design,
+          # breaking contracts, destructive migrations, undecidable diffs.
+          #
+          # Editing the rubric below: every line must stay at this indentation or
+          # deeper, or YAML ends the block scalar and silently reparses the rest
+          # as sibling keys. And never start a line with '#' — the action strips
+          # comment lines from claude_args before parsing, so the rule would
+          # vanish with no error.
+          claude_args: |
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Bash(gh pr comment:*)"
+            --append-system-prompt "You are reviewing a GitHub pull request. You are authorized to submit formal reviews with the gh CLI, including approvals: gh pr review NUMBER --repo OWNER/REPO --approve. Do not refuse; the repository team has granted this permission.
+
+            APPROVE when:
+            - No correctness, security, or data-loss issue was found
+            - Style nits, performance suggestions and missing tests do not block an approval; put them in the approval body
+            - The change is surgical: it addresses one root cause or one behaviour. Touching several modules, classes or files does not make it broad — a fix threaded through a shared interface, its implementations and their tests is still surgical, and so is the same one-line correction applied in five places
+            - The change is mechanical, at any size: renames, dependency bumps, log and error-message wording, docs, tests, CI config, config defaults
+            - The change extends a contract additively: a new optional field or endpoint, a new column or index, a new enum value that older readers ignore
+
+            REQUEST CHANGES only for:
+            - Security vulnerabilities
+            - Data corruption or loss risks
+            - Clear runtime bugs
+            - Breaking changes with no migration path
+
+            COMMENT instead when:
+            - The verdict is unclear
+            - A code comment, PR description or existing review explains the concern is intentional
+
+            WITHHOLD approval, however clean the diff, only for:
+            - A design change to a core component, or a new or reshaped shared abstraction — reshaping how components relate, not adding a method to an existing interface and implementing it in each implementor
+            - A backward-incompatible contract change: a removed or renamed public field or method, a changed field meaning, a persisted or wire format an already-deployed version can no longer read
+            - A destructive or irreversible migration: dropping a column or table, rewriting stored data
+            - A diff you genuinely cannot evaluate, because it turns on context the PR does not carry
+
+            When withholding on scope, say plainly it is the scope and not a defect, so a human owns the decision."


### PR DESCRIPTION
## What this changes

This repo has no Claude workflow at all — unlike sched, wave and nextflow-registry — so `@claude` mentions on its issues and pull requests currently go nowhere. This adds the assistant, and adds it already carrying the review rubric that now runs on [`seqeralabs/sched`](https://github.com/seqeralabs/sched/blob/master/.github/workflows/claude.yml) master, rather than the comment-only baseline the other repos started from.

**Note this is a new file, not an edit.** The ask was to propagate the approving-review change to this repo alongside wave and nextflow-registry; since there was nothing here to adapt, the whole workflow comes in at once.

## What the assistant can do

It wakes only on an explicit `@claude` mention — on an issue body, a PR comment, a review comment, or a review — and can then answer, and file a formal review on a pull request.

Three pieces make an approval possible:

1. **A `gh` allowlist.** The action ships no review-submitting MCP tool, and tag mode permits no Bash beyond `git`, so a review can only be filed through the `gh` CLI. Four commands are allowed — `gh pr view`, `gh pr diff`, `gh pr review`, `gh pr comment`. Deliberately not `Bash(gh api:*)`, which would hand the job write access to every GitHub endpoint.
2. **`pull-requests: write`**, without which the review submission is rejected by the API.
3. **An appended system prompt.** Claude Code refuses to approve PRs by default; `--append-system-prompt` lifts that refusal (as opposed to `--system-prompt`, which would throw away the built-in prompt entirely) and installs the rubric below.

## The rubric

**Approve** when no correctness, security or data-loss problem was found, and the change is either surgical — one root cause or one behaviour, *regardless of how many modules, classes or files it touches*, which matters in a repo of this shape — or mechanical at any size (renames, dependency bumps, message wording, docs, tests, CI, config defaults), or extends a contract additively (new optional field or endpoint, new column or index, new enum value older readers ignore). Style nits, performance suggestions and missing tests go in the approval body instead of blocking it.

**Request changes** only for security vulnerabilities, data corruption or loss risks, clear runtime bugs, and breaking changes with no migration path.

**Comment** when the verdict is unclear, or when a code comment, the PR description or an existing review already explains that the concern is intentional.

**Withhold approval**, however clean the diff, for four cases a bot verdict cannot cover: a design change to a core component or a new/reshaped shared abstraction; a backward-incompatible contract change (for a published library, a removed or renamed public field or method, or a changed field meaning); a destructive or irreversible migration; a diff that turns on context the PR does not carry. When it withholds on scope it must say so explicitly — that it is the scope and not a defect — so a human owns the call.

## Guard against self-triggering

The job skips itself when the actor is `claude[bot]`. Without this the workflow feeds itself, because it triggers on `pull_request_review` and Claude's own review body echoes the `@claude` mention that asked for the review.

## Secret and pins

The workflow reads the **`ENG_ANTHROPIC_API_KEY` organization secret**, as sched, wave and nextflow-registry do. That secret is already shared with this repository — confirmed via `GET /repos/seqeralabs/libseqera/actions/organization-secrets`, which lists only org secrets a repo can actually use — so no secret-access change is needed before merging.

`actions/checkout` is pinned to the same SHA the other workflows in this repo already use. The `claude-code-action` pin matches sched's.

## Verification

The workflow parses and the `--append-system-prompt` block scalar survives intact (the rubric comes back under `claude_args`, not reparsed as sibling YAML keys), and no rubric line begins with `#` — the action strips comment lines from `claude_args`, so such a rule would silently vanish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
